### PR TITLE
Revert "CI: Use lite data file URL secret."

### DIFF
--- a/.github/workflows/nightly-pipeline.yml
+++ b/.github/workflows/nightly-pipeline.yml
@@ -48,4 +48,4 @@ jobs:
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}
       DeviceDetection: ${{ secrets.DEVICE_DETECTION_KEY }}
-      DeviceDetectionUrl: ${{ secrets.IPI_DATA_FILE_LITE_URL }}
+      DeviceDetectionUrl: ${{ secrets.IPI_DATA_FILE_URL }}


### PR DESCRIPTION
This reverts commit 2b36c70f64a928c8e5b0b0a87ea916b88a6f9909.