### PR TITLE
ci: make Ubuntu the PackageRequirement

### DIFF
--- a/ci/options.json
+++ b/ci/options.json
@@ -12,7 +12,6 @@
     "Configuration": "Release",
     "Arch": "x64",
     "BuildMethod": "cmake",
-    "PackageRequirement": true,
     "RunPerformance": true
   },
   {
@@ -26,6 +25,7 @@
     "Name": "Ubuntu_x64_Release",
     "Configuration": "Release",
     "Arch": "x64",
+    "PackageRequirement": true,
     "RunPerformance": true
   },
   {


### PR DESCRIPTION
Publish's Test job depends on the binaries built by the Build job, not PreBuild. Therefore Test stage must run on the same OS as Build.