### PR TITLE
Add `WeightedValuesCollection` API for Go Integration

### DIFF
--- a/VisualStudio/Examples/CPP/ExampleBase/ExampleBase.vcxproj
+++ b/VisualStudio/Examples/CPP/ExampleBase/ExampleBase.vcxproj
@@ -96,6 +96,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/VisualStudio/FiftyOne.IpIntelligence.C/FiftyOne.IpIntelligence.C.vcxproj
+++ b/VisualStudio/FiftyOne.IpIntelligence.C/FiftyOne.IpIntelligence.C.vcxproj
@@ -10,10 +10,12 @@
     <ClInclude Include="..\..\src\fiftyone.h" />
     <ClInclude Include="..\..\src\ip-graph-cxx\graph.h" />
     <ClInclude Include="..\..\src\ipi.h" />
+    <ClInclude Include="..\..\src\ipi_weighted_results.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\ip-graph-cxx\graph.c" />
     <ClCompile Include="..\..\src\ipi.c" />
+    <ClCompile Include="..\..\src\ipi_weighted_results.c" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\common-cxx\VisualStudio\FiftyOne.Common.C\FiftyOne.Common.C.vcxproj">

--- a/VisualStudio/FiftyOne.IpIntelligence.C/FiftyOne.IpIntelligence.C.vcxproj.filters
+++ b/VisualStudio/FiftyOne.IpIntelligence.C/FiftyOne.IpIntelligence.C.vcxproj.filters
@@ -24,12 +24,18 @@
     <ClInclude Include="..\..\src\ip-graph-cxx\graph.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\ipi_weighted_results.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\ipi.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\ip-graph-cxx\graph.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ipi_weighted_results.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/examples/C/IpIntelligence/GettingStarted.c
+++ b/examples/C/IpIntelligence/GettingStarted.c
@@ -181,15 +181,15 @@ static void reportStatus(StatusCode status,
 
 static void printPropertyValueFromResults(ResultsIpi *results) {
 	if (results != NULL && results->count > 0) {
-		printf("IpRangeStart: %s\n", getPropertyValueAsString(results, "IpRangeStart"));
-		printf("IpRangeEnd: %s\n", getPropertyValueAsString(results, "IpRangeEnd"));
-		printf("AccuracyRadius: %s\n", getPropertyValueAsString(results, "AccuracyRadius"));
-		printf("RegisteredCountry: %s\n", getPropertyValueAsString(results, "RegisteredCountry"));
-		printf("RegisteredName: %s\n", getPropertyValueAsString(results, "RegisteredName"));
-		printf("Longitude: %s\n", getPropertyValueAsString(results, "Longitude"));
-		printf("Latitude: %s\n", getPropertyValueAsString(results, "Latitude"));
-		printf("Areas: %s\n", getPropertyValueAsString(results, "Areas"));
-		// printf("Mcc: %s\n", getPropertyValueAsString(results, "Mcc"));
+		printf("- IpRangeStart: %s\n", getPropertyValueAsString(results, "IpRangeStart"));
+		printf("- IpRangeEnd: %s\n", getPropertyValueAsString(results, "IpRangeEnd"));
+		printf("- AccuracyRadius: %s\n", getPropertyValueAsString(results, "AccuracyRadius"));
+		printf("- RegisteredCountry: %s\n", getPropertyValueAsString(results, "RegisteredCountry"));
+		printf("- RegisteredName: %s\n", getPropertyValueAsString(results, "RegisteredName"));
+		printf("- Longitude: %s\n", getPropertyValueAsString(results, "Longitude"));
+		printf("- Latitude: %s\n", getPropertyValueAsString(results, "Latitude"));
+		printf("- Areas: %s\n", getPropertyValueAsString(results, "Areas"));
+		// printf("- Mcc: %s\n", getPropertyValueAsString(results, "Mcc"));
 	}
 	else {
 		printf("No results.");

--- a/src/ipi_weighted_results.c
+++ b/src/ipi_weighted_results.c
@@ -494,8 +494,7 @@ static void PropValuesPopulate(
 
 static void PropValuesMoveItems(
     const PropValues * const values,
-    WeightedValuesCollection * const result,
-    Exception * const exception) {
+    WeightedValuesCollection * const result) {
 
     size_t totalSize = 0;
     uint32_t totalCount = 0;
@@ -532,7 +531,7 @@ static void PropValuesMoveItems(
 WeightedValuesCollection fiftyoneDegreesResultsIpiGetValuesCollection(
     ResultsIpi * const results,
     const int * const requiredPropertyIndexes,
-    const int requiredPropertyIndexesLength,
+    const uint32_t requiredPropertyIndexesLength,
     fiftyoneDegreesData * const tempData,
     Exception * const exception) {
 
@@ -580,7 +579,7 @@ WeightedValuesCollection fiftyoneDegreesResultsIpiGetValuesCollection(
             DataReset(&myTempData);
         }
     }
-    PropValuesMoveItems(&values, &result, exception);
+    PropValuesMoveItems(&values, &result);
     PropValuesRelease(&values);
     if (EXCEPTION_FAILED) {
         fiftyoneDegreesWeightedValuesCollectionRelease(&result);

--- a/src/ipi_weighted_results.c
+++ b/src/ipi_weighted_results.c
@@ -1,0 +1,524 @@
+/* *********************************************************************
+* This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2025 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence (EUPL)
+ * v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+#include "ipi_weighted_results.h"
+#include "fiftyone.h"
+
+MAP_TYPE(WeightedValueHeader);
+MAP_TYPE(WeightedInt);
+MAP_TYPE(WeightedDouble);
+MAP_TYPE(WeightedBool);
+MAP_TYPE(WeightedByte);
+MAP_TYPE(WeightedString);
+MAP_TYPE(WeightedValuesCollection);
+
+typedef struct {
+    int requiredPropertyIndex;
+    Data data;
+} PropValuesChunk;
+
+typedef struct {
+    uint32_t count;
+    Data data;
+    PropValuesChunk *items;
+} PropValues;
+
+static void PropValuesInit(PropValues * const values, const uint32_t count) {
+    values->count = count;
+    DataReset(&values->data);
+    DataMalloc(&values->data, count * sizeof(PropValuesChunk));
+    values->items = (PropValuesChunk *)values->data.ptr;
+    for (uint32_t i = 0, n = values->count; i < n; i++) {
+        DataReset(&values->items[i].data);
+    }
+}
+
+static void PropValuesRelease(PropValues * const values) {
+    if (values->items && values->count > 0) {
+        for (uint32_t i = 0, n = values->count; i < n; i++) {
+            Data * const nextChunkData = &(values->items[i].data);
+            if (nextChunkData->allocated) {
+                Free(nextChunkData->ptr);
+                DataReset(nextChunkData);
+            }
+        }
+    }
+    if (values->data.allocated) {
+        Free(values->data.ptr);
+        DataReset(&values->data);
+    }
+    values->count = 0;
+    values->items = NULL;
+}
+
+
+typedef void (*PropValueInitFunc)(
+    WeightedValueHeader *header,
+    void *converterState);
+typedef void (*PropValueSaveFunc)(
+    WeightedValueHeader *header,
+    const StoredBinaryValue *storedBinaryValue,
+    PropertyValueType propertyValueType,
+    void *converterState,
+    Exception *exception);
+typedef void (*PropValueFreeFunc)(
+    WeightedValueHeader *header);
+
+typedef struct {
+    const char * const name;
+    const PropertyValueType valueType;
+    const PropValueInitFunc itemInitFunc;
+    const PropValueSaveFunc itemSaveFunc;
+    const PropValueFreeFunc itemFreeFunc;
+    const size_t itemSize;
+} PropValuesConverter;
+
+static void InitInt(
+    WeightedValueHeader * const header,
+    void * const converterState) {
+    ((WeightedInt*)header)->value = *(int*)converterState;
+}
+static void SaveInt(
+    WeightedValueHeader * const header,
+    const StoredBinaryValue * const storedBinaryValue,
+    const PropertyValueType propertyValueType,
+    void * const converterState,
+    Exception * const exception) {
+#	ifdef _MSC_VER
+    UNREFERENCED_PARAMETER(exception);
+#	endif
+
+    ((WeightedInt*)header)->value = StoredBinaryValueToIntOrDefault(
+        storedBinaryValue, propertyValueType, *(int*)converterState);
+}
+
+static void InitBool(
+    WeightedValueHeader * const header,
+    void * const converterState) {
+    ((WeightedBool*)header)->value = *(bool*)converterState;
+}
+static void SaveBool(
+    WeightedValueHeader * const header,
+    const StoredBinaryValue * const storedBinaryValue,
+    const PropertyValueType propertyValueType,
+    void * const converterState,
+    Exception * const exception) {
+#	ifdef _MSC_VER
+    UNREFERENCED_PARAMETER(exception);
+#	endif
+
+    ((WeightedBool*)header)->value = StoredBinaryValueToBoolOrDefault(
+        storedBinaryValue, propertyValueType, *(bool*)converterState);
+}
+
+static void InitDouble(
+    WeightedValueHeader * const header,
+    void * const converterState) {
+    ((WeightedDouble*)header)->value = *(double*)converterState;
+}
+static void SaveDouble(
+    WeightedValueHeader * const header,
+    const StoredBinaryValue * const storedBinaryValue,
+    const PropertyValueType propertyValueType,
+    void * const converterState,
+    Exception * const exception) {
+#	ifdef _MSC_VER
+    UNREFERENCED_PARAMETER(exception);
+#	endif
+
+    ((WeightedDouble*)header)->value = StoredBinaryValueToDoubleOrDefault(
+        storedBinaryValue, propertyValueType, *(double*)converterState);
+}
+
+static void InitByte(
+    WeightedValueHeader * const header,
+    void * const converterState) {
+    ((WeightedByte*)header)->value = *(byte*)converterState;
+}
+static void SaveByte(
+    WeightedValueHeader * const header,
+    const StoredBinaryValue * const storedBinaryValue,
+    const PropertyValueType propertyValueType,
+    void * const converterState,
+    Exception * const exception) {
+#	ifdef _MSC_VER
+    UNREFERENCED_PARAMETER(exception);
+#	endif
+
+    ((WeightedByte*)header)->value = (byte)StoredBinaryValueToIntOrDefault(
+        storedBinaryValue, propertyValueType, *(uint8_t*)converterState);
+}
+
+static void InitString(
+    WeightedValueHeader * const header,
+    void * const converterState) {
+#	ifdef _MSC_VER
+    UNREFERENCED_PARAMETER(converterState);
+#	endif
+    WeightedString * const wString = (WeightedString*)header;
+    DataReset(&wString->stringData);
+    wString->value = NULL;
+}
+typedef struct {
+    const uint8_t decimalPlaces;
+    Data * const tempData;
+} StringConverterState;
+static void SaveString(
+    WeightedValueHeader * const header,
+    const StoredBinaryValue * const storedBinaryValue,
+    const PropertyValueType propertyValueType,
+    void * const converterState,
+    Exception * const exception) {
+
+    StringConverterState * const state = (StringConverterState *)converterState;
+    StringBuilder builder = {
+        (char *)state->tempData->ptr,
+        state->tempData->allocated,
+    };
+    StringBuilderInit(&builder);
+    StringBuilderAddStringValue(
+        &builder,
+        storedBinaryValue,
+        propertyValueType,
+        state->decimalPlaces,
+        exception);
+    if (EXCEPTION_OKAY && builder.added > builder.length) {
+        DataMalloc(state->tempData, builder.added + 2);
+        StringBuilderInit(&builder);
+        StringBuilderAddStringValue(
+            &builder,
+            storedBinaryValue,
+            propertyValueType,
+            state->decimalPlaces,
+            exception);
+    }
+    if (EXCEPTION_OKAY) {
+        WeightedString * const wString = (WeightedString*)header;
+        DataMalloc(&wString->stringData, builder.added);
+        memcpy(
+            wString->stringData.ptr,
+            state->tempData->ptr,
+            builder.added);
+    }
+}
+static void FreeString(WeightedValueHeader * const header) {
+    WeightedString * const wString = (WeightedString*)header;
+    if (wString->stringData.allocated) {
+        Free(wString->stringData.ptr);
+        DataReset(&wString->stringData);
+    }
+    wString->value = NULL;
+}
+
+static const PropValuesConverter PropValuesConverter_Int = {
+    "PropValuesConverter_Int",
+    FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_INTEGER,
+    InitInt,
+    SaveInt,
+    NULL,
+    sizeof(WeightedInt),
+};
+static const PropValuesConverter PropValuesConverter_Double = {
+    "PropValuesConverter_Double",
+    FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_DOUBLE,
+    InitDouble,
+    SaveDouble,
+    NULL,
+    sizeof(WeightedDouble),
+};
+static const PropValuesConverter PropValuesConverter_Bool = {
+    "PropValuesConverter_Bool",
+    FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_BOOLEAN,
+    InitBool,
+    SaveBool,
+    NULL,
+    sizeof(WeightedBool),
+};
+static const PropValuesConverter PropValuesConverter_Byte = {
+    "PropValuesConverter_Byte",
+    FIFTYONE_DEGREES_PROPERTY_VALUE_SINGLE_BYTE,
+    InitByte,
+    SaveByte,
+    NULL,
+    sizeof(WeightedByte),
+};
+static const PropValuesConverter PropValuesConverter_String = {
+    "PropValuesConverter_String",
+    FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_STRING,
+    InitString,
+    SaveString,
+    FreeString,
+    sizeof(WeightedString),
+};
+
+
+typedef struct {
+    void * const chunkDataPtr;
+    const ProfilePercentage * const valuesItems;
+    const uint32_t valuesCount;
+    const PropertyValueType storedValueType;
+    Exception * const exception;
+} PropValuesChunkContext;
+
+static void PropValuesChunkPopulate(
+    const PropValuesChunkContext * const context,
+    const PropValuesConverter * const converter,
+    void * const converterState) {
+
+    Exception * const exception = context->exception;
+
+    for (uint32_t i = 0; i < context->valuesCount; i++) {
+        WeightedValueHeader * const header = (WeightedValueHeader *)(
+            converter->itemSize * i + (uint8_t*)context->chunkDataPtr);
+        converter->itemInitFunc(header, converterState);
+    }
+    for (uint32_t i = 0; (i < context->valuesCount) && EXCEPTION_OKAY; i++) {
+        WeightedValueHeader * const header = (WeightedValueHeader *)(
+            converter->itemSize * i + (uint8_t*)context->chunkDataPtr);
+        header->rawWeighting = context->valuesItems[i].rawWeighting;
+        const StoredBinaryValue * const binaryValue = (StoredBinaryValue *)(
+            context->valuesItems[i].item.data.ptr);
+        converter->itemSaveFunc(
+            header,
+            binaryValue,
+            context->storedValueType,
+            converterState,
+            exception);
+    }
+}
+
+static void PropValuesChunkPopulate_Int(
+    const PropValuesChunkContext * const context,
+    const int defaultValue) {
+    PropValuesChunkPopulate(
+        context,
+        &PropValuesConverter_Int,
+        (void *)&defaultValue);
+}
+static void PropValuesChunkPopulate_Double(
+    const PropValuesChunkContext * const context,
+    const double defaultValue) {
+    PropValuesChunkPopulate(
+        context,
+        &PropValuesConverter_Double,
+        (void *)&defaultValue);
+}
+static void PropValuesChunkPopulate_Byte(
+    const PropValuesChunkContext * const context,
+    const byte defaultValue) {
+    PropValuesChunkPopulate(
+        context,
+        &PropValuesConverter_Byte,
+        (void *)&defaultValue);
+}
+static void PropValuesChunkPopulate_Bool(
+    const PropValuesChunkContext * const context,
+    const bool defaultValue) {
+    PropValuesChunkPopulate(
+        context,
+        &PropValuesConverter_Bool,
+        (void *)&defaultValue);
+}
+static void PropValuesChunkPopulate_String(
+    const PropValuesChunkContext * const context,
+    fiftyoneDegreesData * const tempData,
+    const uint8_t decimalPlaces) {
+    StringConverterState state = {
+        decimalPlaces,
+        tempData,
+    };
+    PropValuesChunkPopulate(
+        context,
+        &PropValuesConverter_String,
+        (void *)&state);
+}
+
+typedef struct {
+    int intValue;
+    double doubleValue;
+    bool boolValue;
+    uint8_t byteValue;
+    uint8_t stringDecimalPlaces;
+} PropValuesItemConversionDefaults;
+
+static void PropValuesChunkInit(
+    PropValuesChunk * const chunk,
+    ResultsIpi * const results,
+    const PropValuesItemConversionDefaults * const defaults,
+    fiftyoneDegreesData * const tempData,
+    Exception * const exception) {
+
+    const DataSetIpi * const dataSet = (DataSetIpi*)results->b.dataSet;
+    const uint32_t propertyIndex = PropertiesGetPropertyIndexFromRequiredIndex(
+        dataSet->b.b.available,
+        chunk->requiredPropertyIndex);
+
+    // We should not have any undefined data type in the data file
+    // If there is, the data file is not good to use so terminates.
+    const PropertyValueType valueType = PropertyGetValueType(
+        dataSet->properties, propertyIndex, exception);
+    if (EXCEPTION_FAILED) {
+        return;
+    }
+
+    const PropertyValueType storedValueType = PropertyGetStoredTypeByIndex(
+        dataSet->propertyTypes,
+        propertyIndex,
+        exception);
+    if (EXCEPTION_FAILED) {
+        return;
+    }
+
+    // Get a pointer to the first value item for the property.
+    const ProfilePercentage * const valuesItems = ResultsIpiGetValues(
+        results,
+        chunk->requiredPropertyIndex,
+        exception);
+    if (EXCEPTION_FAILED) {
+        return;
+    }
+    if (valuesItems == NULL) {
+        return;
+    }
+
+    const PropValuesChunkContext context = {
+        chunk,
+        valuesItems,
+        results->values.count,
+        storedValueType,
+        exception,
+    };
+
+    switch (valueType) {
+        case FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_INTEGER:
+            PropValuesChunkPopulate_Int(&context, defaults->intValue);
+            break;
+        case FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_DOUBLE:
+            PropValuesChunkPopulate_Double(&context, defaults->doubleValue);
+            break;
+        case FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_BOOLEAN:
+            PropValuesChunkPopulate_Bool(&context, defaults->boolValue);
+            break;
+        case FIFTYONE_DEGREES_PROPERTY_VALUE_SINGLE_BYTE:
+            PropValuesChunkPopulate_Byte(&context, defaults->byteValue);
+            break;
+        case FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_STRING:
+        default:
+            PropValuesChunkPopulate_String(
+                &context,
+                tempData,
+                defaults->stringDecimalPlaces);
+            break;
+    }
+}
+
+static void PropValuesPopulate(
+    const PropValues * const values,
+    ResultsIpi * const results,
+    const PropValuesItemConversionDefaults * const defaults,
+    fiftyoneDegreesData * const tempData,
+    Exception * const exception) {
+
+    for (uint32_t i = 0, n = values->count; (i < n) && EXCEPTION_OKAY; i++) {
+        PropValuesChunkInit(
+            &values->items[i],
+            results,
+            defaults,
+            tempData,
+            exception);
+    }
+}
+
+static void PropValuesMoveItems(
+    const PropValues * const values,
+    WeightedValuesCollection * const result) {
+
+    // FIXME: Implement
+
+}
+
+WeightedValuesCollection fiftyoneDegreesResultsIpiGetValuesCollection(
+    ResultsIpi * const results,
+    const int * const requiredPropertyIndexes,
+    const int requiredPropertyIndexesLength,
+    fiftyoneDegreesData * const tempData,
+    Exception * const exception) {
+
+    const PropValuesItemConversionDefaults defaults = {
+        0,
+        0.0,
+        false,
+        0x00,
+        MAX_DOUBLE_DECIMAL_PLACES,
+    };
+
+    WeightedValuesCollection result;
+    DataReset(&result.valuesData);
+    DataReset(&result.itemsData);
+    result.items = NULL;
+    result.itemsCount = 0;
+
+    PropValues values;
+
+    const DataSetIpi * const dataSet = (DataSetIpi*)results->b.dataSet;
+    if (requiredPropertyIndexes) {
+        if (requiredPropertyIndexesLength <= 0) {
+            EXCEPTION_SET(INVALID_INPUT);
+            return result;
+        }
+        PropValuesInit(&values, requiredPropertyIndexesLength);
+        for (uint32_t i = 0; i < requiredPropertyIndexesLength; i++) {
+            values.items[i].requiredPropertyIndex = requiredPropertyIndexes[i];
+        }
+    } else {
+        const uint32_t propsCount = dataSet->b.b.available->count;
+        PropValuesInit(&values, propsCount);
+        for (uint32_t i = 0; i < propsCount; i++) {
+            values.items[i].requiredPropertyIndex = (int)i;
+        }
+    }
+    {
+        Data myTempData;
+        Data * const theTempData = (tempData
+            ? tempData
+            : (DataReset(&myTempData), &myTempData));
+        PropValuesPopulate(&values, results, &defaults, theTempData, exception);
+        if ((theTempData == &myTempData) && myTempData.allocated) {
+            Free(myTempData.ptr);
+            DataReset(&myTempData);
+        }
+    }
+    PropValuesMoveItems(&values, &result);
+    PropValuesRelease(&values);
+    return result;
+}
+
+void WeightedValuesCollectionRelease(
+    WeightedValuesCollection * const collection) {
+
+    // FIXME: Implement
+
+    if (collection->itemsData.allocated) {
+        Free(collection->itemsData.ptr);
+    }
+    DataReset(&collection->itemsData);
+}

--- a/src/ipi_weighted_results.h
+++ b/src/ipi_weighted_results.h
@@ -69,14 +69,14 @@ typedef struct fiftyone_degrees_weighted_values_collection_t {
 } fiftyoneDegreesWeightedValuesCollection;
 
 
-fiftyoneDegreesWeightedValuesCollection fiftyoneDegreesResultsIpiGetValuesCollection(
+EXTERNAL fiftyoneDegreesWeightedValuesCollection fiftyoneDegreesResultsIpiGetValuesCollection(
  fiftyoneDegreesResultsIpi *results,
  const int *requiredPropertyIndexes,
  int requiredPropertyIndexesLength,
  fiftyoneDegreesData *tempData,
  fiftyoneDegreesException* exception);
 
-void fiftyoneDegreesWeightedValuesCollectionRelease(
+EXTERNAL void fiftyoneDegreesWeightedValuesCollectionRelease(
  fiftyoneDegreesWeightedValuesCollection *collection);
 
 #endif //FIFTYONE_DEGREES_IPI_WEIGHTED_RESULTS_INCLUDED

--- a/src/ipi_weighted_results.h
+++ b/src/ipi_weighted_results.h
@@ -1,0 +1,82 @@
+/* *********************************************************************
+* This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2025 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence (EUPL)
+ * v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+#ifndef FIFTYONE_DEGREES_IPI_WEIGHTED_RESULTS_INCLUDED
+#define FIFTYONE_DEGREES_IPI_WEIGHTED_RESULTS_INCLUDED
+
+#include "ipi.h"
+#include "common-cxx/bool.h"
+#include "common-cxx/data.h"
+
+typedef struct fiftyone_degrees_weighted_value_header_t {
+ fiftyoneDegreesPropertyValueType valueType; // "exposed" one
+ int requiredPropertyIndex;
+ uint16_t rawWeighting;
+} fiftyoneDegreesWeightedValueHeader;
+
+
+typedef struct fiftyone_degrees_weighted_int_t {
+ fiftyoneDegreesWeightedValueHeader header;
+ int32_t value;
+} fiftyoneDegreesWeightedInt;
+
+typedef struct fiftyone_degrees_weighted_double_t {
+ fiftyoneDegreesWeightedValueHeader header;
+ double value;
+} fiftyoneDegreesWeightedDouble;
+
+typedef struct fiftyone_degrees_weighted_bool_t {
+ fiftyoneDegreesWeightedValueHeader header;
+ bool value;
+} fiftyoneDegreesWeightedBool;
+
+typedef struct fiftyone_degrees_weighted_byte_t {
+ fiftyoneDegreesWeightedValueHeader header;
+ uint8_t value;
+} fiftyoneDegreesWeightedByte;
+
+typedef struct fiftyone_degrees_weighted_string_t {
+ fiftyoneDegreesWeightedValueHeader header;
+ fiftyoneDegreesData stringData; // owns `value` memory
+ const char *value;
+} fiftyoneDegreesWeightedString;
+
+
+typedef struct fiftyone_degrees_weighted_values_collection_t {
+ fiftyoneDegreesData valuesData; // owns "real" data
+ fiftyoneDegreesData itemsData;  // owns `items` ToC
+ fiftyoneDegreesWeightedValueHeader ** items;
+ uint32_t itemsCount;
+} fiftyoneDegreesWeightedValuesCollection;
+
+
+fiftyoneDegreesWeightedValuesCollection fiftyoneDegreesResultsIpiGetValuesCollection(
+ fiftyoneDegreesResultsIpi *results,
+ const int *requiredPropertyIndexes,
+ int requiredPropertyIndexesLength,
+ fiftyoneDegreesData *tempData,
+ fiftyoneDegreesException* exception);
+
+void fiftyoneDegreesWeightedValuesCollectionRelease(
+ fiftyoneDegreesWeightedValuesCollection *collection);
+
+#endif //FIFTYONE_DEGREES_IPI_WEIGHTED_RESULTS_INCLUDED

--- a/src/ipi_weighted_results.h
+++ b/src/ipi_weighted_results.h
@@ -23,52 +23,113 @@
 #ifndef FIFTYONE_DEGREES_IPI_WEIGHTED_RESULTS_INCLUDED
 #define FIFTYONE_DEGREES_IPI_WEIGHTED_RESULTS_INCLUDED
 
+/**
+ * @file ipi_weighted_results.h
+ * @brief Defines structures and functions for handling weighted values in IP Intelligence results.
+ * 
+ * This file provides the data structures and functions needed to work with weighted values
+ * of different types (int, double, bool, byte, string) in the IP Intelligence system.
+ * Weighted values include both the actual value and a weighting that indicates the
+ * confidence or importance of that value.
+ */
+
 #include "ipi.h"
 #include "common-cxx/bool.h"
 #include "common-cxx/data.h"
 
+/**
+ * @brief Header structure for all weighted value types.
+ * 
+ * This structure serves as the common header for all weighted value types,
+ * containing the value type, property index, and raw weighting information.
+ */
 typedef struct fiftyone_degrees_weighted_value_header_t {
- fiftyoneDegreesPropertyValueType valueType; // "exposed" one
- int requiredPropertyIndex;
- uint16_t rawWeighting;
+ fiftyoneDegreesPropertyValueType valueType; /**< The type of the property value */
+ int requiredPropertyIndex;                  /**< Index of the required property */
+ uint16_t rawWeighting;                      /**< Raw confidence weighting value */
 } fiftyoneDegreesWeightedValueHeader;
 
 
+/**
+ * @brief Structure for weighted integer values.
+ * 
+ * Contains a weighted value header and an integer value.
+ */
 typedef struct fiftyone_degrees_weighted_int_t {
- fiftyoneDegreesWeightedValueHeader header;
- int32_t value;
+ fiftyoneDegreesWeightedValueHeader header; /**< Common header for all weighted values */
+ int32_t value;                             /**< The integer value */
 } fiftyoneDegreesWeightedInt;
 
+/**
+ * @brief Structure for weighted double values.
+ * 
+ * Contains a weighted value header and a double value.
+ */
 typedef struct fiftyone_degrees_weighted_double_t {
- fiftyoneDegreesWeightedValueHeader header;
- double value;
+ fiftyoneDegreesWeightedValueHeader header; /**< Common header for all weighted values */
+ double value;                              /**< The double value */
 } fiftyoneDegreesWeightedDouble;
 
+/**
+ * @brief Structure for weighted boolean values.
+ * 
+ * Contains a weighted value header and a boolean value.
+ */
 typedef struct fiftyone_degrees_weighted_bool_t {
- fiftyoneDegreesWeightedValueHeader header;
- bool value;
+ fiftyoneDegreesWeightedValueHeader header; /**< Common header for all weighted values */
+ bool value;                                /**< The boolean value */
 } fiftyoneDegreesWeightedBool;
 
+/**
+ * @brief Structure for weighted byte values.
+ * 
+ * Contains a weighted value header and a byte value.
+ */
 typedef struct fiftyone_degrees_weighted_byte_t {
- fiftyoneDegreesWeightedValueHeader header;
- uint8_t value;
+ fiftyoneDegreesWeightedValueHeader header; /**< Common header for all weighted values */
+ uint8_t value;                             /**< The byte value */
 } fiftyoneDegreesWeightedByte;
 
+/**
+ * @brief Structure for weighted string values.
+ * 
+ * Contains a weighted value header, string data, and a pointer to the string value.
+ * The stringData field owns the memory for the value.
+ */
 typedef struct fiftyone_degrees_weighted_string_t {
- fiftyoneDegreesWeightedValueHeader header;
- fiftyoneDegreesData stringData; // owns `value` memory
- const char *value;
+ fiftyoneDegreesWeightedValueHeader header; /**< Common header for all weighted values */
+ fiftyoneDegreesData stringData;            /**< Data structure that owns the string memory */
+ const char *value;                         /**< Pointer to the string value */
 } fiftyoneDegreesWeightedString;
 
 
+/**
+ * @brief Collection of weighted values.
+ * 
+ * This structure holds a collection of weighted values of various types.
+ * It manages the memory for both the values themselves and the array of pointers to them.
+ */
 typedef struct fiftyone_degrees_weighted_values_collection_t {
- fiftyoneDegreesData valuesData; // owns "real" data
- fiftyoneDegreesData itemsData;  // owns `items` ToC
- fiftyoneDegreesWeightedValueHeader ** items;
- uint32_t itemsCount;
+ fiftyoneDegreesData valuesData;                    /**< Data structure that owns the actual values */
+ fiftyoneDegreesData itemsData;                     /**< Data structure that owns the items table of contents */
+ fiftyoneDegreesWeightedValueHeader ** items;       /**< Array of pointers to weighted value headers */
+ uint32_t itemsCount;                               /**< Number of items in the collection */
 } fiftyoneDegreesWeightedValuesCollection;
 
 
+/**
+ * @brief Gets a collection of weighted values from IP Intelligence results.
+ * 
+ * This function extracts weighted values for specified properties from the results
+ * and returns them as a collection.
+ * 
+ * @param results Pointer to the IP Intelligence results
+ * @param requiredPropertyIndexes Array of required property indexes to extract
+ * @param requiredPropertyIndexesLength Number of indexes in the requiredPropertyIndexes array
+ * @param tempData Temporary data structure for string conversion operations
+ * @param exception Pointer to an exception structure for error handling
+ * @return A collection of weighted values
+ */
 EXTERNAL fiftyoneDegreesWeightedValuesCollection fiftyoneDegreesResultsIpiGetValuesCollection(
  fiftyoneDegreesResultsIpi *results,
  const int *requiredPropertyIndexes,
@@ -76,6 +137,13 @@ EXTERNAL fiftyoneDegreesWeightedValuesCollection fiftyoneDegreesResultsIpiGetVal
  fiftyoneDegreesData *tempData,
  fiftyoneDegreesException* exception);
 
+/**
+ * @brief Releases resources used by a weighted values collection.
+ * 
+ * This function frees all memory allocated for the collection and its items.
+ * 
+ * @param collection Pointer to the collection to release
+ */
 EXTERNAL void fiftyoneDegreesWeightedValuesCollectionRelease(
  fiftyoneDegreesWeightedValuesCollection *collection);
 

--- a/src/ipi_weighted_results.h
+++ b/src/ipi_weighted_results.h
@@ -72,7 +72,7 @@ typedef struct fiftyone_degrees_weighted_values_collection_t {
 EXTERNAL fiftyoneDegreesWeightedValuesCollection fiftyoneDegreesResultsIpiGetValuesCollection(
  fiftyoneDegreesResultsIpi *results,
  const int *requiredPropertyIndexes,
- int requiredPropertyIndexesLength,
+ uint32_t requiredPropertyIndexesLength,
  fiftyoneDegreesData *tempData,
  fiftyoneDegreesException* exception);
 


### PR DESCRIPTION
### Changes

- Add new files that expose values similar to `WeightedValue<T>` C++ template.
  - Convenience API in C that minimizes CGo calls for Go wrapper.
- Updated example code to demonstrate the use of this new functionality.

### Why

- https://github.com/51Degrees/ip-intelligence-cxx/issues/62