### PR TITLE
Update `fiftyone.h` with aliases for `ipi_weighted_results.h`.

### DIFF
--- a/src/fiftyone.h
+++ b/src/fiftyone.h
@@ -25,6 +25,7 @@
 
 #include "ipi.h"
 #include "constantsIpi.h"
+#include "ipi_weighted_results.h"
 #include "common-cxx/fiftyone.h"
 
 // Data types
@@ -39,6 +40,13 @@ MAP_TYPE(Ipv4Range)
 MAP_TYPE(Ipv6Range)
 MAP_TYPE(CombinationProfileIndex)
 MAP_TYPE(ResultProfileIndex)
+MAP_TYPE(WeightedValueHeader)
+MAP_TYPE(WeightedInt)
+MAP_TYPE(WeightedDouble)
+MAP_TYPE(WeightedBool)
+MAP_TYPE(WeightedByte)
+MAP_TYPE(WeightedString)
+MAP_TYPE(WeightedValuesCollection)
 
 // Methods
 #define ResultsIpiCreate fiftyoneDegreesResultsIpiCreate /**< Synonym for #fiftyoneDegreesResultsIpiCreate function. */
@@ -65,6 +73,8 @@ MAP_TYPE(ResultProfileIndex)
 #define IpiGetIpAddressAsString fiftyoneDegreesIpiGetIpAddressAsString /**< Synonym for #fiftyoneDegreesIpiGetIpAddressAsString function. */
 #define IpiGetIpAddressAsByteArray fiftyoneDegreesIpiGetIpAddressAsByteArray /**< Synonym for #fiftyoneDegreesIpiGetIpAddressAsByteArray function. */
 #define IpiIterateProfilesForPropertyAndValue fiftyoneDegreesIpiIterateProfilesForPropertyAndValue /**< Synonym for #fiftyoneDegreesIpiIterateProfilesForPropertyAndValue function. */
+#define ResultsIpiGetValuesCollection fiftyoneDegreesResultsIpiGetValuesCollection /**< Synonym for #fiftyoneDegreesResultsIpiGetValuesCollection function. */
+#define WeightedValuesCollectionRelease fiftyoneDegreesWeightedValuesCollectionRelease /**< Synonym for #fiftyoneDegreesWeightedValuesCollectionRelease function. */
 
 // Constants
 #define DefaultWktDecimalPlaces fiftyoneDegreesDefaultWktDecimalPlaces /**< Synonym for #fiftyoneDegreesDefaultWktDecimalPlaces config. */

--- a/src/ipi_weighted_results.c
+++ b/src/ipi_weighted_results.c
@@ -32,15 +32,6 @@
 #include "ipi_weighted_results.h"
 #include "fiftyone.h"
 
-/* Map types for various weighted value structures */
-MAP_TYPE(WeightedValueHeader);
-MAP_TYPE(WeightedInt);
-MAP_TYPE(WeightedDouble);
-MAP_TYPE(WeightedBool);
-MAP_TYPE(WeightedByte);
-MAP_TYPE(WeightedString);
-MAP_TYPE(WeightedValuesCollection);
-
 
 /**
  * @brief Function type for initializing a property value.


### PR DESCRIPTION
### Changes

- Update `fiftyone.h` with aliases for `ipi_weighted_results.h`.

### Why

- https://github.com/51Degrees/ip-intelligence-cxx/issues/62

### Related

- Expands on #71 