### PR TITLE
Make 1 property not 2

### DIFF
--- a/examples/C/IpIntelligence/Performance.c
+++ b/examples/C/IpIntelligence/Performance.c
@@ -526,7 +526,7 @@ void executeBenchmark(
 
 	PropertiesRequired properties = PropertiesDefault;
 	if (config.allProperties == false) {
-		properties.string = "RegisteredName,Areas";
+		properties.string = "RegisteredName";
 	}
 
 	// // Multi graph operation is being deprecated. There is only one graph.


### PR DESCRIPTION
### Changes

- Remove `Areas` from not-"allProperties" config

### Why

To align with other benchmarks

- .NET - https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/main/Examples/OnPremise/Performance-Console/Program.cs#L333-L336
- Java - https://github.com/51Degrees/ip-intelligence-java-examples/blob/main/console/src/main/java/fiftyone/ipintelligence/examples/console/PerformanceBenchmark.java#L209-L211