### PR TITLE
PERF: Use thread-local reusable buffers for weighted property retreival.

### DIFF
--- a/src/ResultsIpi.cpp
+++ b/src/ResultsIpi.cpp
@@ -458,8 +458,8 @@ IpIntelligence::ResultsIpi::getValuesAsWeightedUTF8StringList(
         [&values](const uint32_t count) {
             values.reserve(count);
         },
-        [&values, &stream, &byteVector](
-            const StoredBinaryValue * const binaryValue,
+        [this, &values](
+            const StoredBinaryValue* const binaryValue,
             const PropertyValueType storedValueType,
             const uint16_t rawWeighting,
             Exception* const exception) {

--- a/src/ResultsIpi.hpp
+++ b/src/ResultsIpi.hpp
@@ -476,6 +476,10 @@ namespace FiftyoneDegrees {
 				const std::function<void()>& onAfterValues);
 
 			fiftyoneDegreesResultsIpi *results;
+
+			// Reusable buffers
+			static thread_local std::stringstream tlsReusableStream;
+			static thread_local std::vector<uint8_t> tlsReusableByteVector;
 		};
 	}
 }


### PR DESCRIPTION
This implements the sugggested change in #97. as there is no direct CPP example performance test this has not been verified and tested. 

This set of changes must be reviewed and tested for performance before merging 