### PR TITLE
Align data file path environment variable in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ In order to perform IP intelligence, you will need to obtain a 51Degrees data fi
 
 By default, the downloaded data file has to be placed in the 'ip-intelligence-data' sub-folder of this repo for the tests and examples to work.
 
+The examples resolve the location of the data file in the following order:
+
+1. A path supplied as a command line argument to the example.
+2. The `51DEGREES_IPI_PATH` environment variable containing an explicit path to the data file.
+3. A search of the parent folder structure for the expected file name in the 'ip-intelligence-data' folder, where the free 'Lite' data file is expected to be placed.
+
+Note that on Linux shells the `51DEGREES_IPI_PATH` variable name starts with a digit, so it must be set with the `env` command, for example `env 51DEGREES_IPI_PATH=/path/to/file.ipi ./GettingStarted`, rather than a plain `export`.
+
 ### Fetching sub-modules
 
 This repository has sub-modules that must be fetched.

--- a/examples/C/IpIntelligence/FindProfiles.c
+++ b/examples/C/IpIntelligence/FindProfiles.c
@@ -97,6 +97,7 @@ There are '1' countries in the data set with code 'gb'.
 #endif
 
 #include <stdio.h>
+#include <stdlib.h>
 #include "../../../src/ipi.h"
 #include "../../../src/fiftyone.h"
 
@@ -210,8 +211,19 @@ int main(int argc, char* argv[]) {
 
 	StatusCode status = SUCCESS;
 	char dataFilePath[FILE_MAX_PATH];
+	// An explicit data file path can be supplied in the 51DEGREES_IPI_PATH
+	// environment variable, otherwise the parent folder structure is searched.
+	const char* envDataFilePath = getenv("51DEGREES_IPI_PATH");
 	if (argc > 1) {
 		strcpy(dataFilePath, argv[1]);
+	}
+	else if (envDataFilePath != NULL && envDataFilePath[0] != '\0') {
+		if (strlen(envDataFilePath) >= sizeof(dataFilePath)) {
+			status = INSUFFICIENT_MEMORY;
+		}
+		else {
+			strcpy(dataFilePath, envDataFilePath);
+		}
 	}
 	else {
 		status = FileGetPath(

--- a/examples/C/IpIntelligence/GettingStarted.c
+++ b/examples/C/IpIntelligence/GettingStarted.c
@@ -144,6 +144,7 @@ Areas: "POLYGON EMPTY":1
 #endif
 
 #include <stdio.h>
+#include <stdlib.h>
 #include "../../../src/ipi.h"
 #include "../../../src/fiftyone.h"
 #include "../../../src/ipi_weighted_results.h"
@@ -351,8 +352,19 @@ int main(int argc, char* argv[]) {
 	// ConfigIpi config = IpiLowMemoryConfig;
 	// ConfigIpi config = IpiBalancedConfig;
 	char dataFilePath[FILE_MAX_PATH];
+	// An explicit data file path can be supplied in the 51DEGREES_IPI_PATH
+	// environment variable, otherwise the parent folder structure is searched.
+	const char* envDataFilePath = getenv("51DEGREES_IPI_PATH");
 	if (argc > 1) {
 		strcpy(dataFilePath, argv[1]);
+	}
+	else if (envDataFilePath != NULL && envDataFilePath[0] != '\0') {
+		if (strlen(envDataFilePath) >= sizeof(dataFilePath)) {
+			status = INSUFFICIENT_MEMORY;
+		}
+		else {
+			strcpy(dataFilePath, envDataFilePath);
+		}
 	}
 	else {
 		status = FileGetPath(

--- a/examples/C/IpIntelligence/MemIpi.c
+++ b/examples/C/IpIntelligence/MemIpi.c
@@ -436,8 +436,19 @@ int main(int argc, char* argv[]) {
 	StatusCode status = SUCCESS;
 	char dataFilePath[FILE_MAX_PATH];
 	char ipAddressFilePath[FILE_MAX_PATH];
+	// An explicit data file path can be supplied in the 51DEGREES_IPI_PATH
+	// environment variable, otherwise the parent folder structure is searched.
+	const char* envDataFilePath = getenv("51DEGREES_IPI_PATH");
 	if (argc > 1) {
 		strcpy(dataFilePath, argv[1]);
+	}
+	else if (envDataFilePath != NULL && envDataFilePath[0] != '\0') {
+		if (strlen(envDataFilePath) >= sizeof(dataFilePath)) {
+			status = INSUFFICIENT_MEMORY;
+		}
+		else {
+			strcpy(dataFilePath, envDataFilePath);
+		}
 	}
 	else {
 		status = FileGetPath(

--- a/examples/C/IpIntelligence/OfflineProcessing.c
+++ b/examples/C/IpIntelligence/OfflineProcessing.c
@@ -121,6 +121,8 @@ Expected content of output file:
 #endif
 #endif
 
+#include <stdlib.h>
+
 #include "../../Base/ExampleBase.h"
 #include "../../../src/ipi.h"
 #include "../../../src/common-cxx/textfile.h"
@@ -335,8 +337,19 @@ int main(int argc, char* argv[]) {
 	char dataFilePath[FILE_MAX_PATH];
 	char ipAddressFilePath[FILE_MAX_PATH];
 	char outputFilePath[FILE_MAX_PATH];
+	// An explicit data file path can be supplied in the 51DEGREES_IPI_PATH
+	// environment variable, otherwise the parent folder structure is searched.
+	const char* envDataFilePath = getenv("51DEGREES_IPI_PATH");
 	if (argc > 1) {
 		strcpy(dataFilePath, argv[1]);
+	}
+	else if (envDataFilePath != NULL && envDataFilePath[0] != '\0') {
+		if (strlen(envDataFilePath) >= sizeof(dataFilePath)) {
+			status = INSUFFICIENT_MEMORY;
+		}
+		else {
+			strcpy(dataFilePath, envDataFilePath);
+		}
 	}
 	else {
 		status = FileGetPath(

--- a/examples/C/IpIntelligence/PerfIpi.c
+++ b/examples/C/IpIntelligence/PerfIpi.c
@@ -70,6 +70,7 @@ Average matching per second: ***
 #define PASSES 1
 #endif
 
+#include <stdlib.h>
 #include <time.h>
 
 #include "../../Base/ExampleBase.h"
@@ -550,8 +551,19 @@ int main(int argc, char* argv[]) {
 	StatusCode status = SUCCESS;
 	char dataFilePath[FILE_MAX_PATH];
 	char ipAddressFilePath[FILE_MAX_PATH];
+	// An explicit data file path can be supplied in the 51DEGREES_IPI_PATH
+	// environment variable, otherwise the parent folder structure is searched.
+	const char* envDataFilePath = getenv("51DEGREES_IPI_PATH");
 	if (argc > 1) {
 		strcpy(dataFilePath, argv[1]);
+	}
+	else if (envDataFilePath != NULL && envDataFilePath[0] != '\0') {
+		if (strlen(envDataFilePath) >= sizeof(dataFilePath)) {
+			status = INSUFFICIENT_MEMORY;
+		}
+		else {
+			strcpy(dataFilePath, envDataFilePath);
+		}
 	}
 	else {
 		status = FileGetPath(

--- a/examples/C/IpIntelligence/Performance.c
+++ b/examples/C/IpIntelligence/Performance.c
@@ -21,6 +21,7 @@
  * ********************************************************************* */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <time.h>
 
  // Include ExmapleBase.h before others as it includes Windows 'crtdbg.h'
@@ -823,6 +824,7 @@ int main(int argc, char* argv[]) {
 	uint16_t numberOfThreads = DEFAULT_NUMBER_OF_THREADS;
 	int iterations = DEFAULT_ITERATIONS;
 	char *outFile = NULL;
+	const char *envDataFilePath = getenv("51DEGREES_IPI_PATH");
 	dataFilePath[0] = '\0';
 	evidenceFilePath[0] = '\0';
 
@@ -870,6 +872,21 @@ int main(int argc, char* argv[]) {
 		else {
 			// Do nothing, this is a value.
 		}
+	}
+
+	// An explicit data file path can be supplied in the 51DEGREES_IPI_PATH
+	// environment variable, otherwise the parent folder structure is searched.
+	if (strlen(dataFilePath) == 0 &&
+		envDataFilePath != NULL && envDataFilePath[0] != '\0') {
+		if (strlen(envDataFilePath) >= sizeof(dataFilePath)) {
+			printf("The data file path in the 51DEGREES_IPI_PATH "
+				"environment variable is too long.\n");
+#ifndef TEST
+			fgetc(stdin);
+#endif
+			return 1;
+		}
+		strcpy(dataFilePath, envDataFilePath);
 	}
 
 	if (strlen(dataFilePath) == 0) {

--- a/examples/C/IpIntelligence/ProcIpi.c
+++ b/examples/C/IpIntelligence/ProcIpi.c
@@ -21,6 +21,7 @@
  * ********************************************************************* */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "../../../src/ipi.h"
 #include "../../../src/fiftyone.h"
@@ -137,8 +138,19 @@ int main(int argc, char* argv[]) {
 	char dataFilePath[FILE_MAX_PATH];
 	StatusCode status = SUCCESS;
 	ConfigIpi config = fiftyoneDegreesIpiInMemoryConfig;
+	// An explicit data file path can be supplied in the 51DEGREES_IPI_PATH
+	// environment variable, otherwise the parent folder structure is searched.
+	const char* envDataFilePath = getenv("51DEGREES_IPI_PATH");
 	if (argc > 1) {
 		strcpy(dataFilePath, argv[1]);
+	}
+	else if (envDataFilePath != NULL && envDataFilePath[0] != '\0') {
+		if (strlen(envDataFilePath) >= sizeof(dataFilePath)) {
+			status = INSUFFICIENT_MEMORY;
+		}
+		else {
+			strcpy(dataFilePath, envDataFilePath);
+		}
 	}
 	else {
 		status = FileGetPath(

--- a/examples/C/IpIntelligence/ReloadFromFile.c
+++ b/examples/C/IpIntelligence/ReloadFromFile.c
@@ -401,8 +401,19 @@ int main(int argc, char* argv[]) {
 	StatusCode status = SUCCESS;
 	char dataFilePath[FILE_MAX_PATH];
 	char ipAddressFilePath[FILE_MAX_PATH];
+	// An explicit data file path can be supplied in the 51DEGREES_IPI_PATH
+	// environment variable, otherwise the parent folder structure is searched.
+	const char* envDataFilePath = getenv("51DEGREES_IPI_PATH");
 	if (argc > 1) {
 		strcpy(dataFilePath, argv[1]);
+	}
+	else if (envDataFilePath != NULL && envDataFilePath[0] != '\0') {
+		if (strlen(envDataFilePath) >= sizeof(dataFilePath)) {
+			status = INSUFFICIENT_MEMORY;
+		}
+		else {
+			strcpy(dataFilePath, envDataFilePath);
+		}
 	}
 	else {
 		status = FileGetPath(

--- a/examples/C/IpIntelligence/ReloadFromMemory.c
+++ b/examples/C/IpIntelligence/ReloadFromMemory.c
@@ -419,8 +419,19 @@ int main(int argc, char* argv[]) {
 	StatusCode status = SUCCESS;
 	char dataFilePath[FILE_MAX_PATH];
 	char ipAddressFilePath[FILE_MAX_PATH];
+	// An explicit data file path can be supplied in the 51DEGREES_IPI_PATH
+	// environment variable, otherwise the parent folder structure is searched.
+	const char *envDataFilePath = getenv("51DEGREES_IPI_PATH");
 	if (argc > 1) {
 		strcpy(dataFilePath, argv[1]);
+	}
+	else if (envDataFilePath != NULL && envDataFilePath[0] != '\0') {
+		if (strlen(envDataFilePath) >= sizeof(dataFilePath)) {
+			status = INSUFFICIENT_MEMORY;
+		}
+		else {
+			strcpy(dataFilePath, envDataFilePath);
+		}
 	}
 	else {
 		status = FileGetPath(

--- a/examples/CPP/IpIntelligence/GettingStarted.cpp
+++ b/examples/CPP/IpIntelligence/GettingStarted.cpp
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <iostream>
+#include <cstdlib>
 #include "../../../src/EngineIpi.hpp"
 #include "ExampleBase.hpp"
 
@@ -202,8 +203,19 @@ namespace FiftyoneDegrees {
 int main(int argc, char *argv[]) {
 	fiftyoneDegreesStatusCode status = FIFTYONE_DEGREES_STATUS_SUCCESS;
 	char dataFilePath[FIFTYONE_DEGREES_FILE_MAX_PATH];
+	// An explicit data file path can be supplied in the 51DEGREES_IPI_PATH
+	// environment variable, otherwise the parent folder structure is searched.
+	const char *envDataFilePath = getenv("51DEGREES_IPI_PATH");
 	if (argc > 1) {
 		strcpy(dataFilePath, argv[1]);
+	}
+	else if (envDataFilePath != NULL && envDataFilePath[0] != '\0') {
+		if (strlen(envDataFilePath) >= sizeof(dataFilePath)) {
+			status = FIFTYONE_DEGREES_STATUS_INSUFFICIENT_MEMORY;
+		}
+		else {
+			strcpy(dataFilePath, envDataFilePath);
+		}
 	}
 	else {
 		status = fiftyoneDegreesFileGetPath(

--- a/examples/CPP/IpIntelligence/MetaData.cpp
+++ b/examples/CPP/IpIntelligence/MetaData.cpp
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <iostream>
+#include <cstdlib>
 #include "../../../src/EngineIpi.hpp"
 #include "ExampleBase.hpp"
 
@@ -178,8 +179,19 @@ namespace FiftyoneDegrees {
 int main(int argc, char* argv[]) {
 	fiftyoneDegreesStatusCode status = FIFTYONE_DEGREES_STATUS_SUCCESS;
 	char dataFilePath[FIFTYONE_DEGREES_FILE_MAX_PATH];
+	// An explicit data file path can be supplied in the 51DEGREES_IPI_PATH
+	// environment variable, otherwise the parent folder structure is searched.
+	const char* envDataFilePath = getenv("51DEGREES_IPI_PATH");
 	if (argc > 1) {
 		strcpy(dataFilePath, argv[1]);
+	}
+	else if (envDataFilePath != NULL && envDataFilePath[0] != '\0') {
+		if (strlen(envDataFilePath) >= sizeof(dataFilePath)) {
+			status = FIFTYONE_DEGREES_STATUS_INSUFFICIENT_MEMORY;
+		}
+		else {
+			strcpy(dataFilePath, envDataFilePath);
+		}
 	}
 	else {
 		status = fiftyoneDegreesFileGetPath(

--- a/examples/CPP/IpIntelligence/ReloadFromFile.cpp
+++ b/examples/CPP/IpIntelligence/ReloadFromFile.cpp
@@ -23,6 +23,7 @@
 #include <string>
 #include <iostream>
 #include <thread>
+#include <cstdlib>
 #include "../../../src/EngineIpi.hpp"
 #include "ExampleBase.hpp"
 
@@ -181,8 +182,19 @@ int main(int argc, char* argv[]) {
 	fiftyoneDegreesStatusCode status = FIFTYONE_DEGREES_STATUS_SUCCESS;
 	char dataFilePath[FIFTYONE_DEGREES_FILE_MAX_PATH];
 	char ipAddressFilePath[FIFTYONE_DEGREES_FILE_MAX_PATH];
+	// An explicit data file path can be supplied in the 51DEGREES_IPI_PATH
+	// environment variable, otherwise the parent folder structure is searched.
+	const char* envDataFilePath = getenv("51DEGREES_IPI_PATH");
 	if (argc > 1) {
 		strcpy(dataFilePath, argv[1]);
+	}
+	else if (envDataFilePath != NULL && envDataFilePath[0] != '\0') {
+		if (strlen(envDataFilePath) >= sizeof(dataFilePath)) {
+			status = FIFTYONE_DEGREES_STATUS_INSUFFICIENT_MEMORY;
+		}
+		else {
+			strcpy(dataFilePath, envDataFilePath);
+		}
 	}
 	else {
 		status = fiftyoneDegreesFileGetPath(

--- a/examples/CPP/IpIntelligence/ReloadFromMemory.cpp
+++ b/examples/CPP/IpIntelligence/ReloadFromMemory.cpp
@@ -23,6 +23,7 @@
 #include <string>
 #include <iostream>
 #include <thread>
+#include <cstdlib>
 #include "../../../src/EngineIpi.hpp"
 #include "ExampleBase.hpp"
 #include "../../../src/common-cxx/fiftyone.h"
@@ -188,8 +189,19 @@ int main(int argc, char* argv[]) {
 	fiftyoneDegreesStatusCode status = FIFTYONE_DEGREES_STATUS_SUCCESS;
 	char dataFilePath[FIFTYONE_DEGREES_FILE_MAX_PATH];
 	char ipAddressFilePath[FIFTYONE_DEGREES_FILE_MAX_PATH];
+	// An explicit data file path can be supplied in the 51DEGREES_IPI_PATH
+	// environment variable, otherwise the parent folder structure is searched.
+	const char* envDataFilePath = getenv("51DEGREES_IPI_PATH");
 	if (argc > 1) {
 		strcpy(dataFilePath, argv[1]);
+	}
+	else if (envDataFilePath != NULL && envDataFilePath[0] != '\0') {
+		if (strlen(envDataFilePath) >= sizeof(dataFilePath)) {
+			status = FIFTYONE_DEGREES_STATUS_INSUFFICIENT_MEMORY;
+		}
+		else {
+			strcpy(dataFilePath, envDataFilePath);
+		}
 	}
 	else {
 		status = fiftyoneDegreesFileGetPath(

--- a/examples/CPP/IpIntelligence/StronglyTyped.cpp
+++ b/examples/CPP/IpIntelligence/StronglyTyped.cpp
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <iostream>
+#include <cstdlib>
 #include "../../../src/EngineIpi.hpp"
 #include "ExampleBase.hpp"
 
@@ -199,8 +200,19 @@ namespace FiftyoneDegrees {
 int main(int argc, char* argv[]) {
 	fiftyoneDegreesStatusCode status = FIFTYONE_DEGREES_STATUS_SUCCESS;
 	char dataFilePath[FIFTYONE_DEGREES_FILE_MAX_PATH];
+	// An explicit data file path can be supplied in the 51DEGREES_IPI_PATH
+	// environment variable, otherwise the parent folder structure is searched.
+	const char* envDataFilePath = getenv("51DEGREES_IPI_PATH");
 	if (argc > 1) {
 		strcpy(dataFilePath, argv[1]);
+	}
+	else if (envDataFilePath != NULL && envDataFilePath[0] != '\0') {
+		if (strlen(envDataFilePath) >= sizeof(dataFilePath)) {
+			status = FIFTYONE_DEGREES_STATUS_INSUFFICIENT_MEMORY;
+		}
+		else {
+			strcpy(dataFilePath, envDataFilePath);
+		}
 	}
 	else {
 		status = fiftyoneDegreesFileGetPath(


### PR DESCRIPTION
## Summary

This change aligns the data file environment variable used by the examples with the convention shared across 51Degrees repositories.

- Each example checks the aligned `51DEGREES_IPI_PATH` environment variable for an explicit data file path after any command line argument and before searching the parent folder structure for the expected file name. Values longer than the path buffer are reported through the existing status handling.
- The README documents the resolution order.

## Notes

- This repository is on-premise only, so there is no resource key change here.
- The aligned name starts with a digit, which POSIX shells do not accept in plain assignments. On Linux and macOS set it with the env command, for example `env 51DEGREES_IPI_PATH=/path/to/file.ipi ./GettingStarted`.
