### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 51Degrees Ip Intelligence API
 
-![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_campaign=c_open_source&utm_content=readme_main "Data rewards the curious") **IP Intelligence in C**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-cxx&utm_content=readme.md&utm_term=51degrees-ip-intelligence-api "Data rewards the curious") **IP Intelligence in C**
 
-[C Documentation](https://51degrees.com/ip-intelligence-cxx/4.1/modules.html) and the [C++ Documentation](https://51degrees.com/ip-intelligence-cxx/4.1/namespaces.html).
+[C Documentation](https://51degrees.com/ip-intelligence-cxx/4.1/modules.html?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-cxx&utm_content=readme.md&utm_term=51degrees-ip-intelligence-api) and the [C++ Documentation](https://51degrees.com/ip-intelligence-cxx/4.1/namespaces.html?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-cxx&utm_content=readme.md&utm_term=51degrees-ip-intelligence-api).
 
 The 51Degrees IP intelligence API is built on the 51Degrees [common API](https://github.com/51Degrees/common-cxx).
 
@@ -10,7 +10,7 @@ The 51Degrees IP intelligence API is built on the 51Degrees [common API](https:/
 
 ### Data file
 
-In order to perform IP intelligence, you will need to obtain a 51Degrees data file.  Lite data file can be obtained for free as specified in the [`ip-intelligence-data/README`](https://github.com/51Degrees/ip-intelligence-data/). To obtain an Enterprise data file please [contact us](https://51degrees.com/contact-us).
+In order to perform IP intelligence, you will need to obtain a 51Degrees data file.  Lite data file can be obtained for free as specified in the [`ip-intelligence-data/README`](https://github.com/51Degrees/ip-intelligence-data/). To obtain an Enterprise data file please [contact us](https://51degrees.com/contact-us?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-cxx&utm_content=readme.md&utm_term=data-file).
 
 By default, the downloaded data file has to be placed in the 'ip-intelligence-data' sub-folder of this repo for the tests and examples to work.
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -7,7 +7,7 @@ The following secrets are required:
     * Example: `github_pat_l0ng_r4nd0m_s7r1ng`
   
 The following secrets are required to run tests:
-* `DEVICE_DETECTION_KEY` - [license key](https://51degrees.com/pricing) for downloading assets (TAC hashes file and TAC CSV data file)
+* `DEVICE_DETECTION_KEY` - [license key](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-cxx&utm_content=ci-readme.md&utm_term=api-specific-ci-approach) for downloading assets (TAC hashes file and TAC CSV data file)
     * Example: `V3RYL0NGR4ND0M57R1NG`
  
 The following secrets are optional:

--- a/examples/Base/ExampleBase.c
+++ b/examples/Base/ExampleBase.c
@@ -136,7 +136,7 @@ void fiftyoneDegreesExampleCheckDataFile(
 			"https://github.com/51Degrees/ip-intelligence-data. "
 			"Find out about the Enterprise data file, which "
 			"includes automatic daily updates, on our pricing "
-			"page: https://51degrees.com/pricing\n"), DATA_FILE_AGE_WARNING);
+			"page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-cxx&utm_content=examples-base-examplebase.c&utm_term=data-file-age-warning\n"), DATA_FILE_AGE_WARNING);
 		printf("\033[0m");
 	}
 
@@ -145,7 +145,7 @@ void fiftyoneDegreesExampleCheckDataFile(
 			"data file. This is used for illustration, and "
 			"has limited accuracy and capabilities. Find "
 			"out about the Enterprise data file on our "
-			"pricing page: https://51degrees.com/pricing\n"));
+			"pricing page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-cxx&utm_content=examples-base-examplebase.c&utm_term=lite-data-file\n"));
 	}
 	if (!CollectionGetIsMemoryOnly()) {
 		COLLECTION_RELEASE(dataset->strings, &item);

--- a/examples/C/IpIntelligence/Performance.c
+++ b/examples/C/IpIntelligence/Performance.c
@@ -67,7 +67,7 @@ static const char* dataDir = "ip-intelligence-data";
 // Note that the Lite data file is only used for illustration, and has
 // limited accuracy and capabilities.
 // Find out about the Enterprise data file on our pricing page:
-// https://51degrees.com/pricing
+// https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-cxx&utm_content=examples-c-ipintelligence-performance.c&utm_term=datafilename
 static const char* dataFileName = "51Degrees-LiteV41.ipi";
 
 // This file contains the 20,000 random IP formatted as header values.


### PR DESCRIPTION
## Summary

Every navigational 51degrees.com and configure.51degrees.com link in this repository now carries the standard UTM query string so the Content Team can trace Matomo campaign traffic to the exact repository, file, and location it came from:

`?utm_source=<github|code|nuget|npm|maven|packagist>&utm_medium=<readme|docs|example|comment|package>&utm_campaign=<repository>&utm_content=<file slug>&utm_term=<location in file>`

8 links across 5 files, in-place URL replacements only. While tagging, http, www, and protocol-relative variants were normalised to https on the bare domain, pre-2026 utm schemes were replaced, and the retired Logo.ashx banner URL was replaced with img/logo.png where present. Functional endpoints (cloud, distributor, devices-v4, bulkdata), test fixtures, license headers, and generated files are untouched.

## Lint

A second commit adds the utm-link-lint workflow, which runs the shared script from 51Degrees/common-ci on pull requests and pushes to main, keeping the convention enforced from now on. The lint check on this PR stays red until 51Degrees/common-ci#207 merges, since the workflow fetches the script from that repository's main.

The full convention is documented in UTM-LINK-TAGGING.md in 51Degrees/internal-common-ci (PR 3).