### PR TITLE
fix IPI Verify test for multi-value weighted properties

### DIFF
--- a/.github/workflows/upload-cache-artifact.yml
+++ b/.github/workflows/upload-cache-artifact.yml
@@ -1,0 +1,45 @@
+name: Upload Cache As Artifact
+
+# Manual utility: restore a date-keyed assets cache (the enterprise .ipi data
+# file the nightly stores via common-ci's fetch-assets) and re-upload it as a
+# downloadable artifact. There is no public API to download an Actions cache
+# blob directly, so this round-trips it through a workflow run.
+
+on:
+  workflow_dispatch:
+    inputs:
+      cache-key:
+        description: 'Exact cache key to restore (e.g. 20260618-DA39A3EE5E6B4B0D3255BFEF95601890AFD80709)'
+        required: true
+        type: string
+      path:
+        description: 'Path that was cached (common-ci caches the "assets" dir)'
+        required: false
+        default: 'assets'
+        type: string
+
+jobs:
+  upload-cache-artifact:
+    name: Restore cache and upload artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Restore cache
+        id: restore
+        uses: actions/cache/restore@v5
+        with:
+          key: ${{ inputs.cache-key }}
+          path: ${{ inputs.path }}
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+
+      - name: List restored files
+        shell: bash
+        run: ls -la "${{ inputs.path }}"
+
+      - name: Upload as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cache-${{ inputs.cache-key }}
+          path: ${{ inputs.path }}
+          retention-days: 1
+          compression-level: 0

--- a/test/EngineIpIntelligenceTests.cpp
+++ b/test/EngineIpIntelligenceTests.cpp
@@ -217,15 +217,21 @@ void EngineIpIntelligenceTests::validateIndex(
 		EXPECT_NO_THROW(*resultsIpi->getValueAsString(index)) << "String value "
 			"for property '" << resultsIpi->getPropertyName(index) << "' at "
 			"index '" << index << "' can't throw exception";
-		EXPECT_NO_THROW(*resultsIpi->getValueAsBool(index)) << "Bool value "
-			"for property '" << resultsIpi->getPropertyName(index) << "' at "
-			"index '" << index << "' can't throw exception";
-		EXPECT_NO_THROW(*resultsIpi->getValueAsInteger(index)) << "Integer value "
-			"for property '" << resultsIpi->getPropertyName(index) << "' at "
-			"index '" << index << "' can't throw exception";
-		EXPECT_NO_THROW(*resultsIpi->getValueAsDouble(index)) << "Double value "
-			"for property '" << resultsIpi->getPropertyName(index) << "' at "
-			"index '" << index << "' can't throw exception";
+		// Scalar bool/integer/double conversions are only defined for a single
+		// value. Weighted properties (e.g. CountryCodesGeographical) can resolve
+		// to multiple values for some IPs - notably anycast addresses that span
+		// several countries - for which these getters throw TooManyValuesException.
+		if (values.getValue().size() == 1) {
+			EXPECT_NO_THROW(*resultsIpi->getValueAsBool(index)) << "Bool value "
+				"for property '" << resultsIpi->getPropertyName(index) << "' at "
+				"index '" << index << "' can't throw exception";
+			EXPECT_NO_THROW(*resultsIpi->getValueAsInteger(index)) << "Integer value "
+				"for property '" << resultsIpi->getPropertyName(index) << "' at "
+				"index '" << index << "' can't throw exception";
+			EXPECT_NO_THROW(*resultsIpi->getValueAsDouble(index)) << "Double value "
+				"for property '" << resultsIpi->getPropertyName(index) << "' at "
+				"index '" << index << "' can't throw exception";
+		}
 	}
 }
 
@@ -259,12 +265,19 @@ void EngineIpIntelligenceTests::validateName(
 				"for property '" << *name << "' can't throw exception";
 			EXPECT_NO_THROW(*resultsIpi->getValueAsString(name)) << "String value "
 				"for property '" << *name << "' can't throw exception";
-			EXPECT_NO_THROW(*resultsIpi->getValueAsBool(name)) << "Bool value "
-				"for property '" << *name << "' can't throw exception";
-			EXPECT_NO_THROW(*resultsIpi->getValueAsInteger(name)) << "Integer value "
-				"for property '" << *name << "' can't throw exception";
-			EXPECT_NO_THROW(*resultsIpi->getValueAsDouble(name)) << "Double value "
-				"for property '" << *name << "' can't throw exception";
+			// Scalar bool/integer/double conversions are only defined for a
+			// single value. Weighted properties (e.g. CountryCodesGeographical)
+			// can resolve to multiple values for some IPs - notably anycast
+			// addresses spanning several countries - for which these getters
+			// throw TooManyValuesException.
+			if (values.getValue().size() == 1) {
+				EXPECT_NO_THROW(*resultsIpi->getValueAsBool(name)) << "Bool value "
+					"for property '" << *name << "' can't throw exception";
+				EXPECT_NO_THROW(*resultsIpi->getValueAsInteger(name)) << "Integer value "
+					"for property '" << *name << "' can't throw exception";
+				EXPECT_NO_THROW(*resultsIpi->getValueAsDouble(name)) << "Double value "
+					"for property '" << *name << "' can't throw exception";
+			}
 		}
 		else {
 			// There are no values returned. This is only allowed when:


### PR DESCRIPTION
The Verify test called scalar bool/integer/double getters on every
property; these throw TooManyValuesException when a weighted property
(e.g. CountryCodesGeographical) returns multiple values, as now happens
for an anycast IP that maps to more than one country.

## Changes
- Assert scalar bool/integer/double conversions only for single-value properties.
- Leave string and weighted-list getters unconditional - they handle multiple values.