### PR TITLE
FEAT: Wire up propertyValueIndex config option (#96)

### DIFF
--- a/src/ipi.c
+++ b/src/ipi.c
@@ -144,8 +144,13 @@ static const uint16_t FULL_RAW_WEIGHTING = 0xFFFFU;
 
 #undef FIFTYONE_DEGREES_CONFIG_ALL_IN_MEMORY
 #define FIFTYONE_DEGREES_CONFIG_ALL_IN_MEMORY true
+// The property value index (propertyValueIndex) is disabled in all the
+// preset configurations: measurements with the 4.5 Enterprise data file
+// (issue #96) showed it increases start up time and memory use considerably
+// without improving detection performance. Set propertyValueIndex to true in
+// a custom configuration to opt in.
 fiftyoneDegreesConfigIpi fiftyoneDegreesIpiInMemoryConfig = {
-	{FIFTYONE_DEGREES_CONFIG_DEFAULT_WITH_INDEX},
+	{FIFTYONE_DEGREES_CONFIG_DEFAULT_NO_INDEX},
 	{0,0,0}, // Strings
 	{0,0,0}, // Components
 	{0,0,0}, // Maps
@@ -163,7 +168,7 @@ fiftyoneDegreesConfigIpi fiftyoneDegreesIpiInMemoryConfig = {
 FIFTYONE_DEGREES_CONFIG_ALL_IN_MEMORY_DEFAULT
 
 fiftyoneDegreesConfigIpi fiftyoneDegreesIpiHighPerformanceConfig = {
-	{ FIFTYONE_DEGREES_CONFIG_DEFAULT_WITH_INDEX },
+	{ FIFTYONE_DEGREES_CONFIG_DEFAULT_NO_INDEX },
 	{ true, 0, FIFTYONE_DEGREES_CACHE_CONCURRENCY }, // Strings
 	{ true, 0, FIFTYONE_DEGREES_CACHE_CONCURRENCY }, // Components
 	{ true, 0, FIFTYONE_DEGREES_CACHE_CONCURRENCY }, // Maps
@@ -193,7 +198,7 @@ fiftyoneDegreesConfigIpi fiftyoneDegreesIpiLowMemoryConfig = {
 };
 
 #define FIFTYONE_DEGREES_IPI_CONFIG_BALANCED \
-{ FIFTYONE_DEGREES_CONFIG_DEFAULT_WITH_INDEX }, \
+{ FIFTYONE_DEGREES_CONFIG_DEFAULT_NO_INDEX }, \
 { FIFTYONE_DEGREES_STRING_LOADED, FIFTYONE_DEGREES_STRING_CACHE_SIZE, FIFTYONE_DEGREES_CACHE_CONCURRENCY }, /* Strings */ \
 { true, 0, FIFTYONE_DEGREES_CACHE_CONCURRENCY }, /* Components */ \
 { true, 0, FIFTYONE_DEGREES_CACHE_CONCURRENCY }, /* Maps */ \
@@ -229,7 +234,7 @@ fiftyoneDegreesConfigIpi fiftyoneDegreesIpiBalancedTempConfig = {
 		true, /* reuseTempFile - ENABLED for better performance */
 		NULL, /* tempDirs */
 		0, /* tempDirCount */
-		true /* propertyValueIndex */
+		false /* propertyValueIndex */
 	},
 	{ FIFTYONE_DEGREES_STRING_LOADED, FIFTYONE_DEGREES_STRING_CACHE_SIZE, FIFTYONE_DEGREES_CACHE_CONCURRENCY }, /* Strings */
 	{ true, 0, FIFTYONE_DEGREES_CACHE_CONCURRENCY }, /* Components */
@@ -529,6 +534,25 @@ static StatusCode initComponentsAvailable(
 	}
 
 	return SUCCESS;
+}
+
+// If the configuration requires a property value index then create it from
+// the profile offsets so that the first value for a profile and an available
+// property can be found without searching the values associated with the
+// profile. The data set operates correctly, if slower, without the index so
+// failure to create one is not treated as an error.
+static void initIndicesPropertyProfile(
+	DataSetIpi* dataSet,
+	Exception* exception) {
+	if (dataSet->config.b.propertyValueIndex == true) {
+		dataSet->b.b.indexPropertyProfile = IndicesPropertyProfileCreateFromOffsets(
+			dataSet->profiles,
+			dataSet->profileOffsets,
+			ProfileOffsetAsPureOffset,
+			dataSet->b.b.available,
+			dataSet->values,
+			exception);
+	}
 }
 
 static int findPropertyIndexByName(
@@ -1051,7 +1075,7 @@ static StatusCode initDataSetFromFile(
 		return status;
 	}
 
-	// Initialise the components available to flag which components have 
+	// Initialise the components available to flag which components have
 	// properties which are to be returned (i.e. available properties).
 	status = initComponentsAvailable(dataSet, exception);
 	if (status != SUCCESS || EXCEPTION_FAILED) {
@@ -1069,6 +1093,18 @@ static StatusCode initDataSetFromFile(
 		}
 		return status;
 	}
+
+	// If configured, create the index of property and profile first value
+	// indexes.
+	initIndicesPropertyProfile(dataSet, exception);
+	if (EXCEPTION_FAILED) {
+		// Delete the temp file if one has been created.
+		if (config->b.useTempFile == true) {
+			FileDelete(dataSet->b.b.fileName);
+		}
+		return status;
+	}
+
 	return status;
 }
 
@@ -1196,6 +1232,13 @@ static StatusCode initDataSetFromMemory(
 	// Initialise the components available to flag which components have
 	// properties which are to be returned (i.e. available properties).
 	status = initComponentsAvailable(dataSet, exception);
+	if (status != SUCCESS || EXCEPTION_FAILED) {
+		return status;
+	}
+
+	// If configured, create the index of property and profile first value
+	// indexes.
+	initIndicesPropertyProfile(dataSet, exception);
 
 	return status;
 }
@@ -1653,7 +1696,9 @@ static uint32_t addValuesFromProfile(
 	DataSetIpi* dataSet,
 	ResultsIpi* results,
 	Profile* profile,
+	uint32_t profileOffset,
 	Property* property,
+	uint32_t availablePropertyIndex,
 	uint16_t rawWeighting,
 	Exception* exception) {
 	uint32_t count;
@@ -1667,16 +1712,31 @@ static uint32_t addValuesFromProfile(
 	state.exception = exception;
 
 	// Iterate over the values associated with the property adding them
-	// to the list of values. Get the number of values available as 
+	// to the list of values. Get the number of values available as
 	// this will be used to increase the size of the list should there
-	// be insufficient space.
-	count = ProfileIterateValuesForProperty(
-		dataSet->values,
-		profile,
-		property,
-		&state,
-		addWeightedValueWithState,
-		exception);
+	// be insufficient space. Use the index of first value indexes if one
+	// was created when the data set was initialised.
+	if (dataSet->b.b.indexPropertyProfile != NULL) {
+		count = ProfileIterateValuesForPropertyWithIndexAndOffset(
+			dataSet->values,
+			dataSet->b.b.indexPropertyProfile,
+			availablePropertyIndex,
+			profileOffset,
+			profile,
+			property,
+			&state,
+			addWeightedValueWithState,
+			exception);
+	}
+	else {
+		count = ProfileIterateValuesForProperty(
+			dataSet->values,
+			profile,
+			property,
+			&state,
+			addWeightedValueWithState,
+			exception);
+	}
 	EXCEPTION_THROW;
 
 	// The count of values should always be lower or the same as the profile
@@ -1690,6 +1750,7 @@ static uint32_t addValuesFromProfile(
 static uint32_t addValuesFromSingleProfile(
 	ResultsIpi* results,
 	Property *property,
+	uint32_t availablePropertyIndex,
 	uint32_t profileOffset,
 	uint16_t rawWeighting,
 	Exception* exception) {
@@ -1716,7 +1777,9 @@ static uint32_t addValuesFromSingleProfile(
 				dataSet,
 				results,
 				profile,
+				profileOffset,
 				property,
+				availablePropertyIndex,
 				rawWeighting,
 				exception);
 			COLLECTION_RELEASE(dataSet->profiles, &profileItem);
@@ -1734,6 +1797,7 @@ static const CollectionKeyType CollectionKeyType_OffsetPercentage = {
 static uint32_t addValuesFromProfileGroup(
 	ResultsIpi * const results,
 	Property * const property,
+	const uint32_t availablePropertyIndex,
 	const uint32_t profileGroupOffset,
 	Exception * const exception) {
 	uint32_t count = 0;
@@ -1766,6 +1830,7 @@ static uint32_t addValuesFromProfileGroup(
 			count += addValuesFromSingleProfile(
 				results,
 				property,
+				availablePropertyIndex,
 				nextWeightedProfileOffset->offset,
 				nextWeightedProfileOffset->rawWeighting,
 				exception);
@@ -1843,6 +1908,7 @@ static uint32_t addValuesFromResult(
 	ResultsIpi* results,
 	ResultIpi* result,
 	Property* property,
+	uint32_t availablePropertyIndex,
 	Exception* exception) {
 	uint32_t count = 0;
 	const DataSetIpi* const dataSet = (DataSetIpi*)results->b.dataSet;
@@ -1859,6 +1925,7 @@ static uint32_t addValuesFromResult(
 					count += addValuesFromSingleProfile(
 						results,
 						property,
+						availablePropertyIndex,
 						profileOffsetValue,
 						FULL_RAW_WEIGHTING,
 						exception);
@@ -1867,6 +1934,7 @@ static uint32_t addValuesFromResult(
 				count += addValuesFromProfileGroup(
 					results,
 					property,
+					availablePropertyIndex,
 					result->graphResult.offset,
 					exception);
 			}
@@ -1879,10 +1947,11 @@ static WeightedItem* getValuesFromResult(
 	ResultsIpi* results,
 	ResultIpi* result,
 	Property* property,
+	uint32_t availablePropertyIndex,
 	Exception* exception) {
-	// There is a profile available for the property requested. 
+	// There is a profile available for the property requested.
 	// Use this to add the values to the results.
-	addValuesFromResult(results, result, property, exception);
+	addValuesFromResult(results, result, property, availablePropertyIndex, exception);
 
 	// Return the first value in the list of items.
 	return results->values.items;
@@ -1929,6 +1998,7 @@ const fiftyoneDegreesWeightedItem* fiftyoneDegreesResultsIpiGetValues(
 					results,
 					&results->items[i],
 					property,
+					(uint32_t)requiredPropertyIndex,
 					exception);
 			}
 
@@ -1969,6 +2039,7 @@ static bool profileHasValidPropertyValue(
 	const DataSetIpi * const dataSet,
 	const uint32_t profileOffset,
 	Property * const property,
+	const uint32_t availablePropertyIndex,
 	Exception * const exception) {
 	Item profileItem;
 	Profile *profile = NULL;
@@ -1987,13 +2058,29 @@ static bool profileHasValidPropertyValue(
 			exception);
 		// If profile is found
 		if (profile != NULL && EXCEPTION_OKAY) {
-			ProfileIterateValuesForProperty(
-				dataSet->values,
-				profile,
-				property,
-				&valueFound,
-				visitProfilePropertyValue,
-				exception);
+			// Use the index of first value indexes if one was created when
+			// the data set was initialised.
+			if (dataSet->b.b.indexPropertyProfile != NULL) {
+				ProfileIterateValuesForPropertyWithIndexAndOffset(
+					dataSet->values,
+					dataSet->b.b.indexPropertyProfile,
+					availablePropertyIndex,
+					profileOffset,
+					profile,
+					property,
+					&valueFound,
+					visitProfilePropertyValue,
+					exception);
+			}
+			else {
+				ProfileIterateValuesForProperty(
+					dataSet->values,
+					profile,
+					property,
+					&valueFound,
+					visitProfilePropertyValue,
+					exception);
+			}
 			COLLECTION_RELEASE(dataSet->profiles, &profileItem);
 		}
 	}
@@ -2043,6 +2130,7 @@ static bool resultGetHasValidPropertyValueOffset(
 							dataSet,
 							profileOffsetValue,
 							property,
+							(uint32_t)requiredPropertyIndex,
 							exception);
 					}
 				} else {
@@ -2066,7 +2154,11 @@ static bool resultGetHasValidPropertyValueOffset(
 						totalWeight += nextWeightedProfileOffset->rawWeighting;
 						if (totalWeight <= FULL_RAW_WEIGHTING) {
 							hasValidOffset = profileHasValidPropertyValue(
-								dataSet, nextWeightedProfileOffset->offset, property, exception);
+								dataSet,
+								nextWeightedProfileOffset->offset,
+								property,
+								(uint32_t)requiredPropertyIndex,
+								exception);
 						} else {
 							EXCEPTION_SET(FIFTYONE_DEGREES_STATUS_CORRUPT_DATA);
 						}

--- a/test/IpiIndexParityTests.cpp
+++ b/test/IpiIndexParityTests.cpp
@@ -1,0 +1,287 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+/**
+ * @file IpiIndexParityTests.cpp
+ * @brief Tests that the property value index (propertyValueIndex
+ * configuration option, issue #96) returns exactly the same values as the
+ * non indexed value search.
+ *
+ * Two managers are created from the same data file with configurations that
+ * differ only in the propertyValueIndex option. The same IP addresses are
+ * then processed by both and every available property is compared for:
+ * - the has values state,
+ * - the number of weighted values,
+ * - each value's weighting,
+ * - the values string representation.
+ */
+
+#include "pch.h"
+#include <gtest/gtest.h>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+extern "C" {
+#include "../src/ipi.h"
+#include "../src/fiftyone.h"
+}
+
+#include "Constants.hpp"
+
+// Buffer size for the values string of a single property.
+static const size_t VALUES_BUFFER_SIZE = 8192;
+
+class IpiIndexParityTests : public ::testing::Test {
+protected:
+	fiftyoneDegreesResourceManager managerWithIndex = { nullptr };
+	fiftyoneDegreesResourceManager managerNoIndex = { nullptr };
+	bool managersInitialised = false;
+	char dataFilePath[FIFTYONE_DEGREES_FILE_MAX_PATH] = "";
+
+	void SetUp() override {
+		// Prefer the small ASN data file included with the
+		// ip-intelligence-data submodule: parity does not depend on the data
+		// file contents, and building the index for a full size file with
+		// the file backed Balanced collections takes many minutes. Fall back
+		// to the data files used by the engine tests.
+		const char* fileNames[] = {
+			"51Degrees-IPIV4AsnIpiV41.ipi",
+			_IpiFileNames[0],
+			_IpiFileNames[1],
+		};
+		fiftyoneDegreesStatusCode status =
+			FIFTYONE_DEGREES_STATUS_FILE_NOT_FOUND;
+		for (size_t i = 0; i < sizeof(fileNames) / sizeof(fileNames[0]); i++) {
+			status = fiftyoneDegreesFileGetPath(
+				_dataFolderName,
+				fileNames[i],
+				dataFilePath,
+				sizeof(dataFilePath));
+			if (status == FIFTYONE_DEGREES_STATUS_SUCCESS) {
+				break;
+			}
+		}
+		if (status != FIFTYONE_DEGREES_STATUS_SUCCESS) {
+			GTEST_SKIP() << "No IP Intelligence data file was found.";
+		}
+
+		// Create one manager with the property value index and one without.
+		// Everything else about the configurations is identical.
+		initManager(&managerWithIndex, true);
+		if (HasFatalFailure()) return;
+		initManager(&managerNoIndex, false);
+		if (HasFatalFailure()) return;
+		managersInitialised = true;
+
+		// Check the index was created for the first manager and not for the
+		// second.
+		fiftyoneDegreesDataSetIpi* dataSet =
+			fiftyoneDegreesDataSetIpiGet(&managerWithIndex);
+		ASSERT_NE(nullptr, dataSet);
+		EXPECT_NE(nullptr, dataSet->b.b.indexPropertyProfile) <<
+			"The property value index should have been created when "
+			"propertyValueIndex is enabled.";
+		fiftyoneDegreesDataSetIpiRelease(dataSet);
+		dataSet = fiftyoneDegreesDataSetIpiGet(&managerNoIndex);
+		ASSERT_NE(nullptr, dataSet);
+		EXPECT_EQ(nullptr, dataSet->b.b.indexPropertyProfile) <<
+			"The property value index should not have been created when "
+			"propertyValueIndex is disabled.";
+		fiftyoneDegreesDataSetIpiRelease(dataSet);
+	}
+
+	void TearDown() override {
+		if (managersInitialised) {
+			fiftyoneDegreesResourceManagerFree(&managerWithIndex);
+			fiftyoneDegreesResourceManagerFree(&managerNoIndex);
+			managersInitialised = false;
+		}
+	}
+
+	void initManager(
+		fiftyoneDegreesResourceManager* manager,
+		bool propertyValueIndex) {
+		FIFTYONE_DEGREES_EXCEPTION_CREATE;
+		fiftyoneDegreesConfigIpi config = fiftyoneDegreesIpiBalancedConfig;
+		config.b.propertyValueIndex = propertyValueIndex;
+		fiftyoneDegreesPropertiesRequired properties =
+			fiftyoneDegreesPropertiesDefault;
+		fiftyoneDegreesStatusCode status = fiftyoneDegreesIpiInitManagerFromFile(
+			manager,
+			&config,
+			&properties,
+			dataFilePath,
+			exception);
+		ASSERT_EQ(FIFTYONE_DEGREES_STATUS_SUCCESS, status) <<
+			fiftyoneDegreesStatusGetMessage(status, dataFilePath);
+		ASSERT_TRUE(FIFTYONE_DEGREES_EXCEPTION_OKAY) <<
+			fiftyoneDegreesExceptionGetMessage(exception);
+	}
+
+	// Processes the IP address with both managers and compares the results
+	// of every available property.
+	void compareIpAddress(const char* ipAddress) {
+		FIFTYONE_DEGREES_EXCEPTION_CREATE;
+		fiftyoneDegreesResultsIpi* resultsWithIndex =
+			fiftyoneDegreesResultsIpiCreate(&managerWithIndex);
+		ASSERT_NE(nullptr, resultsWithIndex);
+		fiftyoneDegreesResultsIpi* resultsNoIndex =
+			fiftyoneDegreesResultsIpiCreate(&managerNoIndex);
+		ASSERT_NE(nullptr, resultsNoIndex);
+
+		fiftyoneDegreesResultsIpiFromIpAddressString(
+			resultsWithIndex,
+			ipAddress,
+			strlen(ipAddress),
+			exception);
+		ASSERT_TRUE(FIFTYONE_DEGREES_EXCEPTION_OKAY) <<
+			fiftyoneDegreesExceptionGetMessage(exception);
+		fiftyoneDegreesResultsIpiFromIpAddressString(
+			resultsNoIndex,
+			ipAddress,
+			strlen(ipAddress),
+			exception);
+		ASSERT_TRUE(FIFTYONE_DEGREES_EXCEPTION_OKAY) <<
+			fiftyoneDegreesExceptionGetMessage(exception);
+
+		const fiftyoneDegreesDataSetIpi* dataSet =
+			(fiftyoneDegreesDataSetIpi*)resultsWithIndex->b.dataSet;
+		const uint32_t availableCount = dataSet->b.b.available->count;
+
+		for (uint32_t i = 0; i < availableCount; i++) {
+			SCOPED_TRACE(
+				std::string("IP address '") + ipAddress +
+				"' required property index " + std::to_string(i));
+
+			// The has values state must be the same.
+			const bool hasValuesWithIndex = fiftyoneDegreesResultsIpiGetHasValues(
+				resultsWithIndex,
+				(int)i,
+				exception);
+			ASSERT_TRUE(FIFTYONE_DEGREES_EXCEPTION_OKAY) <<
+				fiftyoneDegreesExceptionGetMessage(exception);
+			const bool hasValuesNoIndex = fiftyoneDegreesResultsIpiGetHasValues(
+				resultsNoIndex,
+				(int)i,
+				exception);
+			ASSERT_TRUE(FIFTYONE_DEGREES_EXCEPTION_OKAY) <<
+				fiftyoneDegreesExceptionGetMessage(exception);
+			EXPECT_EQ(hasValuesNoIndex, hasValuesWithIndex);
+
+			// The weighted values must be the same, in the same order.
+			const fiftyoneDegreesWeightedItem* firstWithIndex =
+				fiftyoneDegreesResultsIpiGetValues(
+					resultsWithIndex,
+					(int)i,
+					exception);
+			ASSERT_TRUE(FIFTYONE_DEGREES_EXCEPTION_OKAY) <<
+				fiftyoneDegreesExceptionGetMessage(exception);
+			const uint32_t countWithIndex = resultsWithIndex->values.count;
+			const fiftyoneDegreesWeightedItem* firstNoIndex =
+				fiftyoneDegreesResultsIpiGetValues(
+					resultsNoIndex,
+					(int)i,
+					exception);
+			ASSERT_TRUE(FIFTYONE_DEGREES_EXCEPTION_OKAY) <<
+				fiftyoneDegreesExceptionGetMessage(exception);
+			const uint32_t countNoIndex = resultsNoIndex->values.count;
+
+			EXPECT_EQ(firstNoIndex == nullptr, firstWithIndex == nullptr);
+			ASSERT_EQ(countNoIndex, countWithIndex);
+			for (uint32_t j = 0; j < countNoIndex; j++) {
+				EXPECT_EQ(
+					resultsNoIndex->values.items[j].rawWeighting,
+					resultsWithIndex->values.items[j].rawWeighting) <<
+					"Weighting differs for value " << j;
+			}
+
+			// The string representation of the values must be the same.
+			char bufferWithIndex[VALUES_BUFFER_SIZE];
+			char bufferNoIndex[VALUES_BUFFER_SIZE];
+			const size_t addedWithIndex =
+				fiftyoneDegreesResultsIpiGetValuesStringByRequiredPropertyIndex(
+					resultsWithIndex,
+					(int)i,
+					bufferWithIndex,
+					sizeof(bufferWithIndex),
+					"|",
+					exception);
+			ASSERT_TRUE(FIFTYONE_DEGREES_EXCEPTION_OKAY) <<
+				fiftyoneDegreesExceptionGetMessage(exception);
+			const size_t addedNoIndex =
+				fiftyoneDegreesResultsIpiGetValuesStringByRequiredPropertyIndex(
+					resultsNoIndex,
+					(int)i,
+					bufferNoIndex,
+					sizeof(bufferNoIndex),
+					"|",
+					exception);
+			ASSERT_TRUE(FIFTYONE_DEGREES_EXCEPTION_OKAY) <<
+				fiftyoneDegreesExceptionGetMessage(exception);
+			EXPECT_EQ(addedNoIndex, addedWithIndex);
+			EXPECT_STREQ(bufferNoIndex, bufferWithIndex);
+		}
+
+		fiftyoneDegreesResultsIpiFree(resultsWithIndex);
+		fiftyoneDegreesResultsIpiFree(resultsNoIndex);
+	}
+};
+
+// Compares a spread of IPv4 addresses across the address space.
+TEST_F(IpiIndexParityTests, Ipv4Spread) {
+	char ipAddress[64];
+	for (int a = 1; a < 256; a += 24) {
+		for (int b = 0; b < 256; b += 51) {
+			for (int c = 0; c < 256; c += 128) {
+				snprintf(
+					ipAddress,
+					sizeof(ipAddress),
+					"%d.%d.%d.1",
+					a,
+					b,
+					c);
+				compareIpAddress(ipAddress);
+				if (HasFatalFailure()) return;
+			}
+		}
+	}
+}
+
+// Compares specific well known and boundary IP addresses.
+TEST_F(IpiIndexParityTests, KnownAndBoundaryAddresses) {
+	const char* addresses[] = {
+		"0.0.0.0",
+		"8.8.8.8",
+		"1.1.1.1",
+		"185.28.167.77",
+		"255.255.255.255",
+		"::1",
+		"2001:4860:4860::8888",
+		"2606:4700:4700::1111",
+		"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+	};
+	for (size_t i = 0; i < sizeof(addresses) / sizeof(addresses[0]); i++) {
+		compareIpAddress(addresses[i]);
+		if (HasFatalFailure()) return;
+	}
+}


### PR DESCRIPTION
Implements #96 (with a negative performance verdict — see below and the issue
comment before deciding to merge vs. close).

Requires the companion common-cxx PR (profile offset keyed index):
https://github.com/51Degrees/common-cxx/pull/145

## What

The preset configurations set `propertyValueIndex = true` but nothing ever
created or used the index. This PR wires it up end to end:

- `initIndicesPropertyProfile` creates the index in both the file and memory
  init paths after `initComponentsAvailable` when
  `config.b.propertyValueIndex == true`, using the new
  `IndicesPropertyProfileCreateFromOffsets` (IPI data files contain no profile
  ids, so the index is keyed by profile offset). Freeing was already handled by
  the common `DataSetFree`.
- The required property index is plumbed from `ResultsIpiGetValues` and
  `resultGetHasValidPropertyValueOffset` down to the two lookup sites
  (`addValuesFromProfile`, `profileHasValidPropertyValue`), which use
  `ProfileIterateValuesForPropertyWithIndexAndOffset` when the index exists.
- **All preset configurations are changed to `NO_INDEX`** — the feature is
  opt-in via a custom configuration only (see measurements).
- New `test/IpiIndexParityTests.cpp`: two managers from the same data file,
  configurations differing only in `propertyValueIndex`; asserts the index
  is/is not created and compares per property, for an IPv4 spread plus
  known/boundary IPv4+IPv6 addresses: has-values state, weighted value count,
  every `rawWeighting`, and the values string. Prefers the small submodule ASN
  file so CI cost is seconds, not minutes.

## Measurements (why the presets are NO_INDEX)

4.5 Enterprise file (5.79 GB, 35,338,173 profiles, 49 available properties),
Windows x64 Release, single threaded, all property values retrieved per IP:

| Metric | index off | index on |
|---|---|---|
| Manager init (InMemory) | 3.2–5.6 s | 14.4–15.3 s (~3–4.5×) |
| Index memory | — | ~6.7 GB (1.73 B cells, 38% filled) |
| Detection, 10k IPs × 49 props | 1.55–2.10 s | 2.04–3.33 s (slower) |
| Value checksums | identical | identical |

Balanced (file backed) config: index build on the Enterprise file did not
finish (killed after 19 minutes); even on the 6.3 MB ASN file it multiplies
init time ~120×.

Root cause analysis is on the issue: the non-indexed first-value search is
already a cache-hot integer binary search inside the just-fetched profile,
while the offset keyed lookup costs ~26 cache misses; the dominant per-value
cost (Value/string collection fetches) is identical on both paths.

## Reviewer note

Given the numbers, an equally valid resolution is to **not merge the wiring**
and instead only take the preset-config change (`WITH_INDEX` → `NO_INDEX`), so
the configs stop advertising a flag that does nothing. Happy to split that out
if preferred.
