### PR TITLE
PERF: Route value lookups to the owning component (stacks on #135)

### DIFF
--- a/src/ipi.c
+++ b/src/ipi.c
@@ -45,6 +45,19 @@ MAP_TYPE(Collection)
 /** Default values separator */
 #define DEFAULT_VALUES_SEPARATOR "|"
 
+/**
+ * States for the entries of the has values cache in the results. The cache
+ * records the outcome of the profile walk performed to determine whether a
+ * required property has values for the current results avoiding repeated
+ * walks for the same property within a single detection.
+ */
+/** The walk has not been performed for the property. */
+#define IPI_HAS_VALUES_UNKNOWN 0
+/** The walk found at least one value for the property. */
+#define IPI_HAS_VALUES_TRUE 1
+/** The walk found no values for the property. */
+#define IPI_HAS_VALUES_FALSE 2
+
 #define COMPONENT(d, i) i < d->componentsList.count ? \
 (Component*)d->componentsList.items[i].data.ptr : NULL
 
@@ -259,6 +272,7 @@ FIFTYONE_DEGREES_CONFIG_USE_TEMP_FILE_DEFAULT
 static void resultIpiReset(ResultIpi* result) {
 	memset(result->targetIpAddress.value, 0, FIFTYONE_DEGREES_IPV6_LENGTH);
 	result->targetIpAddress.type = IP_TYPE_INVALID;
+	result->componentIndex = -1;
 }
 
 static int compareIpAddresses(
@@ -1365,6 +1379,20 @@ FIFTYONE_DEGREES_DATASET_RELOAD(Ipi)
  * Results methods
  */
 
+/**
+ * Marks all the entries in the has values cache as unknown. Must be called
+ * whenever the results are repopulated as the cached outcomes only relate
+ * to the results they were recorded for.
+ */
+static void resultsIpiResetHasValuesCache(ResultsIpi* const results) {
+	if (results->hasValuesCache != NULL) {
+		memset(
+			results->hasValuesCache,
+			IPI_HAS_VALUES_UNKNOWN,
+			results->hasValuesCacheCount);
+	}
+}
+
 fiftyoneDegreesResultsIpi* fiftyoneDegreesResultsIpiCreate(
 	fiftyoneDegreesResourceManager* manager) {
 	ResultsIpi* results;
@@ -1385,10 +1413,26 @@ fiftyoneDegreesResultsIpi* fiftyoneDegreesResultsIpiCreate(
 		// Initialise the results.
 		fiftyoneDegreesResultsInit(&results->b, (void*)(&dataSet->b));
 
-		// Reset the property and values list ready for first use sized for 
+		// Reset the property and values list ready for first use sized for
 		// a single value to be returned.
 		WeightedItemListInit(&results->values, 1, FIFTYONE_DEGREES_WEIGHTED_ITEM_LIST_DEFAULT_LOAD_FACTOR);
 		DataReset(&results->propertyItem.data);
+
+		// Allocate the cache used to avoid repeating the profile walks
+		// which check whether a property has values for the current
+		// results. If the allocation fails the cache is not used.
+		results->hasValuesCache = NULL;
+		results->hasValuesCacheCount = 0;
+		if (dataSet->b.b.available != NULL &&
+			dataSet->b.b.available->count > 0) {
+			results->hasValuesCache = (byte*)Malloc(
+				dataSet->b.b.available->count);
+			if (results->hasValuesCache != NULL) {
+				results->hasValuesCacheCount =
+					dataSet->b.b.available->count;
+				resultsIpiResetHasValuesCache(results);
+			}
+		}
 	}
 	else {
 		DataSetRelease((DataSetBase *)dataSet);
@@ -1410,6 +1454,11 @@ static void resultsIpiRelease(ResultsIpi* results) {
 void fiftyoneDegreesResultsIpiFree(fiftyoneDegreesResultsIpi* results) {
 	resultsIpiRelease(results);
 	WeightedItemListFree(&results->values);
+	if (results->hasValuesCache != NULL) {
+		Free(results->hasValuesCache);
+		results->hasValuesCache = NULL;
+		results->hasValuesCacheCount = 0;
+	}
 	DataSetRelease((DataSetBase*)results->b.dataSet);
 	Free(results);
 }
@@ -1438,6 +1487,10 @@ static bool addResultsFromIpAddressNoChecks(
 		nextResult->graphResult.rawOffset = NULL_PROFILE_OFFSET; // Default IP range offset
 		nextResult->targetIpAddress.type = type;
 		nextResult->type = type;
+		// Record the component the result relates to so that property
+		// lookups can be routed to the result for the component that owns
+		// the property.
+		nextResult->componentIndex = (int32_t)componentIndex;
 
 		if (type == IP_TYPE_IPV4) {
 			// We only get the exact length of ipv4
@@ -1480,6 +1533,7 @@ void fiftyoneDegreesResultsIpiFromIpAddress(
 
 	// Reset the results data before iterating the evidence.
 	results->count = 0;
+	resultsIpiResetHasValuesCache(results);
 
 	addResultsFromIpAddressNoChecks(
 		results,
@@ -1606,6 +1660,7 @@ void fiftyoneDegreesResultsIpiFromEvidence(
 	if (evidence != (EvidenceKeyValuePairArray*)NULL) {
 		// Reset the results data before iterating the evidence.
 		results->count = 0;
+		resultsIpiResetHasValuesCache(results);
 
 		fiftyoneDegreesIterateHeadersWithEvidence(
 			results,
@@ -1867,7 +1922,7 @@ static uint32_t getProfileOffset(
 }
 
 /**
- * Achieves the same as getValuesFromResult, but gets the value from the
+ * Achieves the same as addValuesFromResult, but gets the value from the
  * default value in the property. This is used when there is no value in
  * the profile, but the property is mandatory.
  */
@@ -1992,14 +2047,22 @@ const fiftyoneDegreesWeightedItem* fiftyoneDegreesResultsIpiGetValues(
 				results->propertyItem.collection = dataSet->properties;
 			}
 
-			// There will only be one result
+			// Only the result for the component that owns the property can
+			// hold values for it. Profiles only carry values for properties
+			// of their own component, so the results for other components
+			// are skipped. This keeps the index aware lookup wired up for
+			// the propertyValueIndex config option unchanged for the owning
+			// component while removing the redundant walks over the others.
 			for (uint32_t i = 0; i < results->count && EXCEPTION_OKAY; i++) {
-				firstValue = getValuesFromResult(
-					results,
-					&results->items[i],
-					property,
-					(uint32_t)requiredPropertyIndex,
-					exception);
+				if (results->items[i].componentIndex ==
+					(int32_t)property->componentIndex) {
+					firstValue = getValuesFromResult(
+						results,
+						&results->items[i],
+						property,
+						(uint32_t)requiredPropertyIndex,
+						exception);
+				}
 			}
 
 			if (results->values.count == 0 &&
@@ -2087,15 +2150,86 @@ static bool profileHasValidPropertyValue(
 	return valueFound;
 }
 
-static bool resultGetHasValidPropertyValueOffset(
-	fiftyoneDegreesResultsIpi* const results,
+static bool resultHasValidPropertyValueOffset(
+	const DataSetIpi * const dataSet,
 	const fiftyoneDegreesResultIpi* const result,
-	const int requiredPropertyIndex,
+	Property * const property,
+	const uint32_t availablePropertyIndex,
 	fiftyoneDegreesException* const exception) {
 	bool hasValidOffset = false;
 	Item item;
 	DataReset(&item.data);
+
+	// We will only execute this step if successfully obtained the
+	// profile groups offset from the previous step
+	if (result->graphResult.rawOffset != NULL_PROFILE_OFFSET) {
+		if (!result->graphResult.isGroupOffset) {
+			const uint32_t profileOffsetValue = getProfileOffset(
+				dataSet->profileOffsets,
+				result->graphResult.offset,
+				exception);
+			if (EXCEPTION_OKAY) {
+				hasValidOffset = profileHasValidPropertyValue(
+					dataSet,
+					profileOffsetValue,
+					property,
+					availablePropertyIndex,
+					exception);
+			}
+		} else {
+			const Collection * const profileGroups = dataSet->profileGroups;
+			for (uint32_t totalWeight = 0,
+				nextOffset = result->graphResult.offset;
+				(!hasValidOffset) && (totalWeight < FULL_RAW_WEIGHTING) && EXCEPTION_OKAY;
+				++nextOffset) {
+				const CollectionKey profileGroupKey = {
+					nextOffset,
+					&CollectionKeyType_OffsetPercentage,
+				};
+				const offsetPercentage* const nextWeightedProfileOffset = (const offsetPercentage*)profileGroups->get(
+					profileGroups,
+					&profileGroupKey,
+					&item,
+					exception);
+				if (!(nextWeightedProfileOffset && EXCEPTION_OKAY)) {
+					break;
+				}
+				totalWeight += nextWeightedProfileOffset->rawWeighting;
+				if (totalWeight <= FULL_RAW_WEIGHTING) {
+					hasValidOffset = profileHasValidPropertyValue(
+						dataSet,
+						nextWeightedProfileOffset->offset,
+						property,
+						availablePropertyIndex,
+						exception);
+				} else {
+					EXCEPTION_SET(FIFTYONE_DEGREES_STATUS_CORRUPT_DATA);
+				}
+				COLLECTION_RELEASE(profileGroups, &item);
+			}
+		}
+	}
+	return hasValidOffset;
+}
+
+static bool resultsGetHasValidPropertyValueOffset(
+	fiftyoneDegreesResultsIpi* const results,
+	const int requiredPropertyIndex,
+	fiftyoneDegreesException* const exception) {
+	bool hasValidOffset = false;
 	const DataSetIpi * const dataSet = (DataSetIpi*)results->b.dataSet;
+
+	// Return the outcome of a previous walk over the same results for the
+	// property if one was recorded.
+	const bool canUseCache = results->hasValuesCache != NULL &&
+		requiredPropertyIndex >= 0 &&
+		(uint32_t)requiredPropertyIndex < results->hasValuesCacheCount;
+	if (canUseCache) {
+		const byte cached = results->hasValuesCache[requiredPropertyIndex];
+		if (cached != IPI_HAS_VALUES_UNKNOWN) {
+			return cached == IPI_HAS_VALUES_TRUE;
+		}
+	}
 
 	// Work out the property index from the required property index.
 	const int32_t propertyIndex = PropertiesGetPropertyIndexFromRequiredIndex(
@@ -2112,59 +2246,33 @@ static bool resultGetHasValidPropertyValueOffset(
 			&results->propertyItem,
 			exception);
 
-		const char * const propertyName = STRING( // name is string
-			PropertiesGetNameFromRequiredIndex(
-				dataSet->b.b.available,
-				requiredPropertyIndex));
-		if (propertyName != NULL && EXCEPTION_OKAY) {
-			// We will only execute this step if successfully obtained the
-			// profile groups offset from the previous step
-			if (result->graphResult.rawOffset != NULL_PROFILE_OFFSET) {
-				if (!result->graphResult.isGroupOffset) {
-					const uint32_t profileOffsetValue = getProfileOffset(
-						dataSet->profileOffsets,
-						result->graphResult.offset,
+		if (property != NULL && EXCEPTION_OKAY) {
+			// Only the result for the component that owns the property can
+			// hold values for it. Profiles only carry values for properties
+			// of their own component, so the results for other components
+			// are skipped. The per result check preserves the index aware
+			// lookup wired up for the propertyValueIndex config option.
+			for (uint32_t i = 0;
+				i < results->count && !hasValidOffset && EXCEPTION_OKAY;
+				i++) {
+				if (results->items[i].componentIndex ==
+					(int32_t)property->componentIndex) {
+					hasValidOffset = resultHasValidPropertyValueOffset(
+						dataSet,
+						&results->items[i],
+						property,
+						(uint32_t)requiredPropertyIndex,
 						exception);
-					if (EXCEPTION_OKAY) {
-						hasValidOffset = profileHasValidPropertyValue(
-							dataSet,
-							profileOffsetValue,
-							property,
-							(uint32_t)requiredPropertyIndex,
-							exception);
-					}
-				} else {
-					const Collection * const profileGroups = dataSet->profileGroups;
-					for (uint32_t totalWeight = 0,
-						nextOffset = result->graphResult.offset;
-						(!hasValidOffset) && (totalWeight < FULL_RAW_WEIGHTING) && EXCEPTION_OKAY;
-						++nextOffset) {
-						const CollectionKey profileGroupKey = {
-							nextOffset,
-							&CollectionKeyType_OffsetPercentage,
-						};
-						const offsetPercentage* const nextWeightedProfileOffset = (const offsetPercentage*)profileGroups->get(
-							profileGroups,
-							&profileGroupKey,
-							&item,
-							exception);
-						if (!(nextWeightedProfileOffset && EXCEPTION_OKAY)) {
-							break;
-						}
-						totalWeight += nextWeightedProfileOffset->rawWeighting;
-						if (totalWeight <= FULL_RAW_WEIGHTING) {
-							hasValidOffset = profileHasValidPropertyValue(
-								dataSet,
-								nextWeightedProfileOffset->offset,
-								property,
-								(uint32_t)requiredPropertyIndex,
-								exception);
-						} else {
-							EXCEPTION_SET(FIFTYONE_DEGREES_STATUS_CORRUPT_DATA);
-						}
-						COLLECTION_RELEASE(profileGroups, &item);
-					}
 				}
+			}
+
+			// Record the outcome of the walk so that later has values or
+			// no value reason calls for the same property and results do
+			// not need to repeat it.
+			if (EXCEPTION_OKAY && canUseCache) {
+				results->hasValuesCache[requiredPropertyIndex] =
+					hasValidOffset ?
+					IPI_HAS_VALUES_TRUE : IPI_HAS_VALUES_FALSE;
 			}
 		}
 	}
@@ -2189,19 +2297,17 @@ bool fiftyoneDegreesResultsIpiGetHasValues(
 		// There is no result
 		return false;
 
-	// There will only be one result
-	for (uint32_t i = 0; i < results->count; i++) {
-		const bool hasValidOffset = resultGetHasValidPropertyValueOffset(
-			results,
-			&results->items[i],
-			requiredPropertyIndex,
-			exception);
-		if (EXCEPTION_FAILED) {
-			return false;
-		}
-		if (hasValidOffset) {
-			return true;
-		}
+	// Check the result for the component the property belongs to. The
+	// outcome of a previous walk for the property is used if available.
+	const bool hasValidOffset = resultsGetHasValidPropertyValueOffset(
+		results,
+		requiredPropertyIndex,
+		exception);
+	if (EXCEPTION_FAILED) {
+		return false;
+	}
+	if (hasValidOffset) {
+		return true;
 	}
 	const uint32_t propertyIndex = PropertiesGetPropertyIndexFromRequiredIndex(
 		dataSet->b.b.available,
@@ -2243,19 +2349,17 @@ fiftyoneDegreesResultsNoValueReason fiftyoneDegreesResultsIpiGetNoValueReason(
 		return FIFTYONE_DEGREES_RESULTS_NO_VALUE_REASON_NO_RESULTS;
 	}
 
-	// There will only be one result
-	for (uint32_t i = 0; i < results->count; i++) {
-		const bool hasValidOffset = resultGetHasValidPropertyValueOffset(
-			results,
-			&results->items[i],
-			requiredPropertyIndex,
-			exception);
-		if (EXCEPTION_FAILED) {
-			return false;
-		}
-		if (hasValidOffset) {
-			return FIFTYONE_DEGREES_RESULTS_NO_VALUE_REASON_UNKNOWN;
-		}
+	// Check the result for the component the property belongs to. The
+	// outcome of a previous walk for the property is used if available.
+	const bool hasValidOffset = resultsGetHasValidPropertyValueOffset(
+		results,
+		requiredPropertyIndex,
+		exception);
+	if (EXCEPTION_FAILED) {
+		return false;
+	}
+	if (hasValidOffset) {
+		return FIFTYONE_DEGREES_RESULTS_NO_VALUE_REASON_UNKNOWN;
 	}
 	if (EXCEPTION_OKAY) {
 		return FIFTYONE_DEGREES_RESULTS_NO_VALUE_REASON_NULL_PROFILE;

--- a/src/ipi.h
+++ b/src/ipi.h
@@ -334,6 +334,9 @@ typedef struct fiftyone_degrees_result_ipi_t {
 												 graph evaluation */
 	fiftyoneDegreesIpAddress targetIpAddress; /**< The target IP address
 											  to find a matching range for */
+	int32_t componentIndex; /**< Index in the components list of the
+							component the result relates to, or -1 if the
+							result has not been populated */
 } fiftyoneDegreesResultIpi;
 
 /**
@@ -342,7 +345,12 @@ typedef struct fiftyone_degrees_result_ipi_t {
 #define FIFTYONE_DEGREES_RESULTS_IPI_MEMBERS \
 	fiftyoneDegreesResultsBase b; \
 	fiftyoneDegreesCollectionItem propertyItem; \
-	fiftyoneDegreesIpiList values;
+	fiftyoneDegreesIpiList values; \
+	byte* hasValuesCache; /**< Cached outcomes of the profile walks used to \
+						  check if a property has values. Indexed by required \
+						  property index. Reset when the results are \
+						  repopulated. */ \
+	uint32_t hasValuesCacheCount; /**< Number of entries in hasValuesCache */
 
 FIFTYONE_DEGREES_ARRAY_TYPE(
 	fiftyoneDegreesResultIpi,


### PR DESCRIPTION
Draft, stacked on top of #135 (feature/property-value-index-96). Merge #135 first, this targets that branch so the diff shows only the additional change.

## Performance addition
A small optimization to the value retrieval path. A profile only holds values for properties of its own component, so when a request materializes properties spanning several components (the shape a cloud AsDictionary call produces) the lookup only needs to consult the result for the owning component.

This change adds that routing:
- Each result records the index of the component it relates to (new field, set as results are populated).
- The value lookup, the has values check and the no value reason check consult only the result whose component owns the property.
- A small per results cache records the outcome of the has values walk so a following has values or no value reason call for the same property can reuse it. It is reset when the results are repopulated.

The propertyValueIndex work from #135 is preserved. The index aware lookup is threaded through unchanged for the owning component, so this only reduces how many results are visited, not how a value is found.

## Testing
- Parity: ParityDump over 3000 addresses with all properties, this branch vs #135 without the change, byte identical (150001 value lines, matching md5). The same md5 also matches main and the standalone change off main, so results are unchanged across all four.
- Throughput: PerformanceC, LowMemory, all properties, 8 threads, 5 rounds interleaved on the 6.1 GB enterprise file. main median 120 dets/s, #135 median 120, this branch median 155 (+29 percent), every round above both baselines.
- Builds warning clean (VS18, x64, /W4 /WX).
- Left as the CI and reviewer gate: the full IpiTests suite (the standalone change off main passed 536/536, worth running again on this stacked variant) and the InMemory / index on profile numbers, which this dev box cannot measure reliably (RAM constrained).

## Why this order
The property value index is active in the index on profiles (InMemory, Balanced). This routing reduces work on every profile including the index off LowMemory path that on premise deployments use, so the two changes are complementary. A standalone version off main is on branch perf/value-path if a direct to main route is preferred.
