### PR TITLE
CONFIG: Set IPI presets to NO_INDEX (#96)

### DIFF
--- a/src/ipi.c
+++ b/src/ipi.c
@@ -145,7 +145,7 @@ static const uint16_t FULL_RAW_WEIGHTING = 0xFFFFU;
 #undef FIFTYONE_DEGREES_CONFIG_ALL_IN_MEMORY
 #define FIFTYONE_DEGREES_CONFIG_ALL_IN_MEMORY true
 fiftyoneDegreesConfigIpi fiftyoneDegreesIpiInMemoryConfig = {
-	{FIFTYONE_DEGREES_CONFIG_DEFAULT_WITH_INDEX},
+	{FIFTYONE_DEGREES_CONFIG_DEFAULT_NO_INDEX},
 	{0,0,0}, // Strings
 	{0,0,0}, // Components
 	{0,0,0}, // Maps
@@ -163,7 +163,7 @@ fiftyoneDegreesConfigIpi fiftyoneDegreesIpiInMemoryConfig = {
 FIFTYONE_DEGREES_CONFIG_ALL_IN_MEMORY_DEFAULT
 
 fiftyoneDegreesConfigIpi fiftyoneDegreesIpiHighPerformanceConfig = {
-	{ FIFTYONE_DEGREES_CONFIG_DEFAULT_WITH_INDEX },
+	{ FIFTYONE_DEGREES_CONFIG_DEFAULT_NO_INDEX },
 	{ true, 0, FIFTYONE_DEGREES_CACHE_CONCURRENCY }, // Strings
 	{ true, 0, FIFTYONE_DEGREES_CACHE_CONCURRENCY }, // Components
 	{ true, 0, FIFTYONE_DEGREES_CACHE_CONCURRENCY }, // Maps
@@ -193,7 +193,7 @@ fiftyoneDegreesConfigIpi fiftyoneDegreesIpiLowMemoryConfig = {
 };
 
 #define FIFTYONE_DEGREES_IPI_CONFIG_BALANCED \
-{ FIFTYONE_DEGREES_CONFIG_DEFAULT_WITH_INDEX }, \
+{ FIFTYONE_DEGREES_CONFIG_DEFAULT_NO_INDEX }, \
 { FIFTYONE_DEGREES_STRING_LOADED, FIFTYONE_DEGREES_STRING_CACHE_SIZE, FIFTYONE_DEGREES_CACHE_CONCURRENCY }, /* Strings */ \
 { true, 0, FIFTYONE_DEGREES_CACHE_CONCURRENCY }, /* Components */ \
 { true, 0, FIFTYONE_DEGREES_CACHE_CONCURRENCY }, /* Maps */ \
@@ -229,7 +229,7 @@ fiftyoneDegreesConfigIpi fiftyoneDegreesIpiBalancedTempConfig = {
 		true, /* reuseTempFile - ENABLED for better performance */
 		NULL, /* tempDirs */
 		0, /* tempDirCount */
-		true /* propertyValueIndex */
+		false /* propertyValueIndex */
 	},
 	{ FIFTYONE_DEGREES_STRING_LOADED, FIFTYONE_DEGREES_STRING_CACHE_SIZE, FIFTYONE_DEGREES_CACHE_CONCURRENCY }, /* Strings */
 	{ true, 0, FIFTYONE_DEGREES_CACHE_CONCURRENCY }, /* Components */


### PR DESCRIPTION
Sets all IPI preset configurations to `NO_INDEX`, so they stop advertising a `propertyValueIndex=true` flag that nothing in IP Intelligence ever creates or uses.

## Why

Per the measurements and code analysis on #96, the property value index does not benefit IP Intelligence:

- IPI's data format has no profile ids, so the device-detection index cannot be reused; the only possible keying is by profile offset.
- The non-indexed first-value lookup is already a cache-hot, bounded integer binary search inside the just-fetched profile record - not a scan of the value collection. The index would only replace that already-cheap step, while the dominant per-value cost (fetching each `Value` and its string) is identical either way.
- Empirically: no detection speed-up (15-25% slower), ~6.7 GB extra RAM, and 3-4.5x longer startup; file-backed index builds do not finish in practical time.

Today the flag is a pure no-op on `main` (nothing reads it), so this change has no runtime effect on its own. It stops the presets from advertising a capability that does not exist, and - if the wiring in #135 is ever merged - is what keeps the multi-GB index from being built by default.

## Scope

- `src/ipi.c` only: `InMemory`, `HighPerformance`, and the `BALANCED` macro (covers `Balanced` + `Default`) switch `CONFIG_DEFAULT_WITH_INDEX` -> `CONFIG_DEFAULT_NO_INDEX`; `BalancedTemp` sets its inline `propertyValueIndex` to `false`. `LowMemory` was already `NO_INDEX`.
- The `propertyValueIndex` field itself is **not** removed: it lives in the shared common-cxx `ConfigBase` and device detection genuinely uses it. It stays available as an opt-in via a custom configuration.

Refs #96.
