### PR TITLE
FEAT: Read data files with profile offsets stored in 8 byte units

### DIFF
--- a/src/ipi.c
+++ b/src/ipi.c
@@ -146,10 +146,13 @@ static const uint16_t FULL_RAW_WEIGHTING = 0xFFFFU;
 /*
  * The minor version from which the profiles collection stores offsets, and
  * the collection length in the header, in 8 byte units rather than bytes.
- * Profile records in such files are aligned to 8 byte boundaries by the
- * exporter so that the 32 bit stored offsets can address profile data up to
- * 32GB. Only supported when compiled with large data file support, as the
- * arithmetic to convert stored offsets to byte positions requires 64 bits.
+ * Profile records in such files are aligned by the exporter to 8 byte
+ * boundaries relative to the start of the collection, which is what the
+ * stored offsets are relative to, so that the 32 bit stored offsets can
+ * address profile data up to 32GB. The start of the collection itself need
+ * not be aligned. Only supported when compiled with large data file support,
+ * as the arithmetic to convert stored offsets to byte positions requires 64
+ * bits.
  */
 #define FIFTYONE_DEGREES_IPI_SHIFTED_PROFILES_VERSION_MINOR 6
 /* The number of bits to shift a stored profile offset left to get bytes */

--- a/src/ipi.c
+++ b/src/ipi.c
@@ -142,6 +142,20 @@ static const uint16_t FULL_RAW_WEIGHTING = 0xFFFFU;
 #define FIFTYONE_DEGREES_IPI_TARGET_VERSION_MAJOR 4
 #define FIFTYONE_DEGREES_IPI_TARGET_VERSION_MINOR 5
 
+#ifdef FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT
+/*
+ * The minor version from which the profiles collection stores offsets, and
+ * the collection length in the header, in 8 byte units rather than bytes.
+ * Profile records in such files are aligned to 8 byte boundaries by the
+ * exporter so that the 32 bit stored offsets can address profile data up to
+ * 32GB. Only supported when compiled with large data file support, as the
+ * arithmetic to convert stored offsets to byte positions requires 64 bits.
+ */
+#define FIFTYONE_DEGREES_IPI_SHIFTED_PROFILES_VERSION_MINOR 6
+/* The number of bits to shift a stored profile offset left to get bytes */
+#define FIFTYONE_DEGREES_IPI_PROFILES_OFFSET_SHIFT 3
+#endif
+
 #undef FIFTYONE_DEGREES_CONFIG_ALL_IN_MEMORY
 #define FIFTYONE_DEGREES_CONFIG_ALL_IN_MEMORY true
 fiftyoneDegreesConfigIpi fiftyoneDegreesIpiInMemoryConfig = {
@@ -694,14 +708,38 @@ static StatusCode readHeaderFromMemory(
 }
 
 static StatusCode checkVersion(DataSetIpi* dataSet) {
-	if (!(dataSet->header.versionMajor ==
-		FIFTYONE_DEGREES_IPI_TARGET_VERSION_MAJOR &&
-		dataSet->header.versionMinor ==
-		FIFTYONE_DEGREES_IPI_TARGET_VERSION_MINOR)) {
+	if (dataSet->header.versionMajor !=
+		FIFTYONE_DEGREES_IPI_TARGET_VERSION_MAJOR) {
 		return INCORRECT_VERSION;
 	}
-	return SUCCESS;
+	if (dataSet->header.versionMinor ==
+		FIFTYONE_DEGREES_IPI_TARGET_VERSION_MINOR) {
+		return SUCCESS;
+	}
+#ifdef FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT
+	// Files with shifted profile offsets can only be read when compiled
+	// with large data file support, as converting the stored offsets to
+	// byte positions requires 64 bit arithmetic.
+	if (dataSet->header.versionMinor ==
+		FIFTYONE_DEGREES_IPI_SHIFTED_PROFILES_VERSION_MINOR) {
+		return SUCCESS;
+	}
+#endif
+	return INCORRECT_VERSION;
 }
+
+/**
+ * Gets the number of bits to shift a stored profile offset left to convert
+ * it to a byte position within the profiles collection. Zero for files
+ * where profile offsets are byte positions.
+ */
+#ifdef FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT
+static byte getProfilesOffsetShift(const DataSetIpi* dataSet) {
+	return dataSet->header.versionMinor >=
+		FIFTYONE_DEGREES_IPI_SHIFTED_PROFILES_VERSION_MINOR ?
+		FIFTYONE_DEGREES_IPI_PROFILES_OFFSET_SHIFT : 0;
+}
+#endif
 
 static void initDataSetPost(
 	DataSetIpi* dataSet,
@@ -776,7 +814,19 @@ static StatusCode initWithMemory(
 
 	const uint32_t profileCount = dataSet->header.profiles.count;
 	*(uint32_t*)(&dataSet->header.profiles.count) = 0;
+#ifdef FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT
+	// The profiles collection may store offsets in 8 byte units depending
+	// on the data file version. No other collection uses shifted offsets.
+	dataSet->profiles = fiftyoneDegreesCollectionCreateFromMemoryWithOffsetShift(
+		reader,
+		dataSet->header.profiles,
+		getProfilesOffsetShift(dataSet));
+	if (dataSet->profiles == NULL) {
+		return INVALID_COLLECTION_CONFIG;
+	}
+#else
 	COLLECTION_CREATE_MEMORY(profiles)
+#endif
 	*(uint32_t*)(&dataSet->header.profiles.count) = profileCount;
 
 	COLLECTION_CREATE_MEMORY(graphs);
@@ -894,7 +944,22 @@ static StatusCode readDataSetFromFile(
 
 	const uint32_t profileCount = dataSet->header.profiles.count;
 	*(uint32_t*)(&dataSet->header.profiles.count) = 0;
+#ifdef FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT
+	// The profiles collection may store offsets in 8 byte units depending
+	// on the data file version. No other collection uses shifted offsets.
+	dataSet->profiles = fiftyoneDegreesCollectionCreateFromFileWithOffsetShift(
+		file,
+		&dataSet->b.b.filePool,
+		&dataSet->config.profiles,
+		dataSet->header.profiles,
+		fiftyoneDegreesProfileReadFromFile,
+		getProfilesOffsetShift(dataSet));
+	if (dataSet->profiles == NULL) {
+		return INVALID_COLLECTION_CONFIG;
+	}
+#else
 	COLLECTION_CREATE_FILE(profiles, fiftyoneDegreesProfileReadFromFile);
+#endif
 	*(uint32_t*)(&dataSet->header.profiles.count) = profileCount;
 
 	COLLECTION_CREATE_FILE(graphs, CollectionReadFileFixed);


### PR DESCRIPTION
Data files of version 4.6 store profile offsets, and the profiles collection length, in 8 byte units with each profile record aligned by the exporter to an 8 byte boundary relative to the start of the collection, which is what the stored offsets are relative to. The 32 bit fields which hold them can then address profile data up to 32GB rather than 4GB. The current enterprise file's profiles collection is at 3.03GB of the 4GB the current format can address.

The profiles collection is created with an offset shift of 3 for version 4.6 files so the conversion to byte positions happens inside the collection layer, and every consumer of profile offsets, including the profile groups and component default profiles, is unchanged. Version 4.5 files read exactly as before. Builds without FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT reject version 4.6 files with INCORRECT_VERSION as the conversion needs 64 bit arithmetic.

Requires 51Degrees/common-cxx#148, which adds the offset unit shift to collections, and the submodule pointer should move to its merge commit before this merges. The data file exporter is being updated separately to write version 4.6 files.

Verified by syntax checking with and without the compile flag. Not yet built or run against the test suites.
